### PR TITLE
fix(server): get campaign fetches executions from db

### DIFF
--- a/chutney/server-core/src/main/java/com/chutneytesting/server/core/domain/scenario/campaign/CampaignExecution.java
+++ b/chutney/server-core/src/main/java/com/chutneytesting/server/core/domain/scenario/campaign/CampaignExecution.java
@@ -29,10 +29,13 @@ import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalInt;
+import java.util.function.BinaryOperator;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -241,9 +244,14 @@ public class CampaignExecution {
     private List<ScenarioExecutionCampaign> filterRetry(List<ScenarioExecutionCampaign> scenarioExecutionReports) {
         return scenarioExecutionReports.stream()
             .filter(Objects::nonNull)
-            .collect(Collectors.groupingBy(s -> s.scenarioId))
-            .values().stream()
-            .map(list -> list.size() == 1 ? list.get(0) : list.stream().max(Comparator.comparing(objet -> objet.execution.time())).get())
+            .collect(Collectors.toMap(
+                s -> s.scenarioId,
+                Function.identity(),
+                BinaryOperator.maxBy(Comparator.comparing(s -> s.execution.time())),
+                    LinkedHashMap::new // Keep the insertion order
+                ))
+            .values()
+            .stream()
             .toList();
     }
 


### PR DESCRIPTION
#### Issue Number
fixes #
<!-- Please Mention the issue number as #(Issue Number) Example: #5 -->

#### Describe the changes you've made
Get campaign running execution from db instead of in-memory cache.
Why? to get the exact scenario execution Id.
<!-- A clear and concise description of what you have done to successfully close the issue.
Any new files? or anything you feel to let us know! -->

#### Describe if there is any unusual behaviour of your code <!-- Write `NA` if there isn't -->

<!-- A clear and concise description of it. -->

#### Additional context <!-- OPTIONAL -->

<!-- Add any other context or screenshots about the feature request here -->

#### Test plan <!-- OPTIONAL -->

<!-- A good test plan should give instructions that someone else can easily follow.
How someone can test your code? -->

#### Checklist

<!-- To tick a checkbox, replace the whitespace by the letter 'x' such as: [x] -->

- [ ] Refer to issue(s) the PR solves
- [x] New java code is covered by tests
- [ ] Add screenshots or gifs of the new behavior, if applicable.
- [x] All new and existing tests pass
- [x] No git conflict
