### PR TITLE
fix(server): getLastExecutions returns the last running exec if available, otherwise the last exec

### DIFF
--- a/chutney/server/src/main/java/com/chutneytesting/execution/infra/storage/DatabaseExecutionHistoryRepository.java
+++ b/chutney/server/src/main/java/com/chutneytesting/execution/infra/storage/DatabaseExecutionHistoryRepository.java
@@ -81,12 +81,11 @@ class DatabaseExecutionHistoryRepository implements ExecutionHistoryRepository {
 
     @Override
     @Transactional(readOnly = true)
-    public Map<String, ExecutionSummary> getLastExecutions(List<String> scenarioIds) {
-        List<String> scenarioIdL = scenarioIds.stream().filter(id -> !invalidScenarioId(id)).toList();
-        Iterable<ScenarioExecutionEntity> lastExecutions = scenarioExecutionsJpaRepository.findAllById(
-            scenarioExecutionsJpaRepository.findLastExecutionsByScenarioId(scenarioIdL)
-                .stream().map(t -> t.get(0, Long.class)).toList()
-        );
+    public Map<String, ExecutionSummary> getLastExecutions(List<String> scenariosIds) {
+        List<String> validScenariosIds = scenariosIds.stream().filter(id -> !invalidScenarioId(id)).toList();
+        List<Long> executionsIds = scenarioExecutionsJpaRepository.findLastExecutionsByScenarioId(validScenariosIds)
+            .stream().map(t -> t.get(0, Long.class)).toList();
+        Iterable<ScenarioExecutionEntity> lastExecutions = scenarioExecutionsJpaRepository.findAllById(executionsIds );
         return StreamSupport.stream(lastExecutions.spliterator(), true)
             .collect(Collectors.toMap(ScenarioExecutionEntity::scenarioId, ScenarioExecutionEntity::toDomain));
     }

--- a/chutney/server/src/main/java/com/chutneytesting/execution/infra/storage/DatabaseExecutionHistoryRepository.java
+++ b/chutney/server/src/main/java/com/chutneytesting/execution/infra/storage/DatabaseExecutionHistoryRepository.java
@@ -83,7 +83,7 @@ class DatabaseExecutionHistoryRepository implements ExecutionHistoryRepository {
     @Transactional(readOnly = true)
     public Map<String, ExecutionSummary> getLastExecutions(List<String> scenariosIds) {
         List<String> validScenariosIds = scenariosIds.stream().filter(id -> !invalidScenarioId(id)).toList();
-        List<Long> executionsIds = scenarioExecutionsJpaRepository.findLastExecutionsByScenarioId(validScenariosIds)
+        List<Long> executionsIds = scenarioExecutionsJpaRepository.findLastByStatusAndScenariosIds(validScenariosIds, ServerReportStatus.RUNNING)
             .stream().map(t -> t.get(0, Long.class)).toList();
         Iterable<ScenarioExecutionEntity> lastExecutions = scenarioExecutionsJpaRepository.findAllById(executionsIds );
         return StreamSupport.stream(lastExecutions.spliterator(), true)

--- a/chutney/server/src/main/java/com/chutneytesting/execution/infra/storage/DatabaseExecutionJpaRepository.java
+++ b/chutney/server/src/main/java/com/chutneytesting/execution/infra/storage/DatabaseExecutionJpaRepository.java
@@ -31,11 +31,18 @@ public interface DatabaseExecutionJpaRepository extends JpaRepository<ScenarioEx
 
     List<ScenarioExecutionEntity> findByScenarioIdOrderByIdDesc(String scenarioId);
 
+    /**
+     * Finds the last executions with the specified status <b>if available</b>, otherwise the last executions.
+     *
+     * @param scenarioIds A list of scenario IDs to filter the executions by.
+     * @param status      The status to filter the executions by.
+     * @return A list of tuples representing the last execution id and the scenario id.
+     */
     @Query("""
             SELECT
                 CASE
-                    WHEN EXISTS (SELECT 1 FROM SCENARIO_EXECUTIONS se_tmp WHERE se_tmp.scenarioId = se.scenarioId AND se_tmp.status = 'RUNNING')
-                        THEN MAX(CASE WHEN se.status = 'RUNNING' THEN se.id END)
+                    WHEN EXISTS (SELECT 1 FROM SCENARIO_EXECUTIONS se_tmp WHERE se_tmp.scenarioId = se.scenarioId AND se_tmp.status = :status)
+                        THEN MAX(CASE WHEN se.status = :status THEN se.id END)
                     ELSE MAX(CASE WHEN se.status != 'NOT_EXECUTED' THEN se.id END)
                     END AS max_id,
                 se.scenarioId
@@ -46,7 +53,7 @@ public interface DatabaseExecutionJpaRepository extends JpaRepository<ScenarioEx
             GROUP BY
                 se.scenarioId
             """)
-    List<Tuple> findLastExecutionsByScenarioId(@Param("scenarioIds") List<String> scenarioIds);
+        List<Tuple> findLastByStatusAndScenariosIds(@Param("scenarioIds") List<String> scenarioIds, @Param("status")  ServerReportStatus status);
 
     List<ScenarioExecutionEntity> findAllByScenarioId(String scenarioId);
 

--- a/chutney/server/src/test/java/com/chutneytesting/execution/infra/storage/DatabaseExecutionHistoryRepositoryTest.java
+++ b/chutney/server/src/test/java/com/chutneytesting/execution/infra/storage/DatabaseExecutionHistoryRepositoryTest.java
@@ -192,6 +192,20 @@ public class DatabaseExecutionHistoryRepositoryTest {
             assertThat(lastExecutions.get(scenarioIdOne).status()).isEqualTo(SUCCESS);
         }
 
+
+        @Test
+        public void last_execution_return_last_running_even_if_it_is_not_the_last_exec() {
+            String scenarioIdOne = givenScenarioId();
+            sut.store(scenarioIdOne, buildDetachedExecution(RUNNING, "exec1", ""));
+            sut.store(scenarioIdOne, buildDetachedExecution(RUNNING, "exec2", ""));
+            sut.store(scenarioIdOne, buildDetachedExecution(SUCCESS, "exec3", ""));
+
+            Map<String, ExecutionSummary> lastExecutions = sut.getLastExecutions(List.of(scenarioIdOne));
+            assertThat(lastExecutions).containsOnlyKeys(scenarioIdOne);
+            assertThat(lastExecutions.get(scenarioIdOne).info()).hasValue("exec2");
+            assertThat(lastExecutions.get(scenarioIdOne).status()).isEqualTo(RUNNING);
+        }
+
         @Test
         public void storage_keeps_all_items() {
             String scenarioId = givenScenarioId();


### PR DESCRIPTION
…able, otherwise the last exec

#### Issue Number
fixes #
<!-- Please Mention the issue number as #(Issue Number) Example: #5 -->

#### Describe the changes you've made
`GetLastExecutions` returns the last running exec if available, otherwise the last exec
see [this ](https://github.com/chutney-testing/chutney/blob/9f2e2c7ea6d49f278317596f01e93a35586cc9ba/chutney/server/src/test/java/com/chutneytesting/execution/infra/storage/DatabaseExecutionHistoryRepositoryTest.java#L197)test
<!-- A clear and concise description of what you have done to successfully close the issue.
Any new files? or anything you feel to let us know! -->

#### Describe if there is any unusual behaviour of your code <!-- Write `NA` if there isn't -->

<!-- A clear and concise description of it. -->

#### Additional context <!-- OPTIONAL -->

<!-- Add any other context or screenshots about the feature request here -->

#### Test plan <!-- OPTIONAL -->

<!-- A good test plan should give instructions that someone else can easily follow.
How someone can test your code? -->

#### Checklist

<!-- To tick a checkbox, replace the whitespace by the letter 'x' such as: [x] -->

- [ ] Refer to issue(s) the PR solves
- [ ] New java code is covered by tests
- [ ] Add screenshots or gifs of the new behavior, if applicable.
- [ ] All new and existing tests pass
- [ ] No git conflict
