### PR TITLE
feat(server): enable offset reset before consuming from kafka

### DIFF
--- a/chutney/action-impl/src/main/java/com/chutneytesting/action/kafka/CustomConsumerRebalanceListener.java
+++ b/chutney/action-impl/src/main/java/com/chutneytesting/action/kafka/CustomConsumerRebalanceListener.java
@@ -1,0 +1,31 @@
+/*
+ *  Copyright 2017-2023 Enedis
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chutneytesting.action.kafka;
+
+import java.util.Collection;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.common.TopicPartition;
+import org.springframework.kafka.listener.ConsumerAwareRebalanceListener;
+
+public class CustomConsumerRebalanceListener implements ConsumerAwareRebalanceListener {
+    @Override
+    public void onPartitionsAssigned(Consumer<?, ?> consumer, Collection<TopicPartition> partitions) {
+        ConsumerAwareRebalanceListener.super.onPartitionsAssigned(consumer, partitions);
+        consumer.seekToBeginning(partitions);
+    }
+}

--- a/chutney/action-impl/src/main/java/com/chutneytesting/action/kafka/KafkaConsumerFactoryFactory.java
+++ b/chutney/action-impl/src/main/java/com/chutneytesting/action/kafka/KafkaConsumerFactoryFactory.java
@@ -24,6 +24,7 @@ import static org.apache.kafka.clients.consumer.ConsumerConfig.GROUP_ID_CONFIG;
 import com.chutneytesting.action.spi.injectable.Target;
 import java.util.HashMap;
 import java.util.Map;
+import org.apache.kafka.common.config.SslConfigs;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
@@ -36,8 +37,8 @@ public class KafkaConsumerFactoryFactory {
         consumerConfig.put(BOOTSTRAP_SERVERS_CONFIG, resolveBootStrapServerConfig(target));
         consumerConfig.put(GROUP_ID_CONFIG, group);
         target.trustStore().ifPresent(trustStore -> {
-          consumerConfig.put("ssl.truststore.location", trustStore);
-          consumerConfig.put("ssl.truststore.password", target.trustStorePassword().orElseThrow(IllegalArgumentException::new));
+            consumerConfig.put(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, trustStore);
+            consumerConfig.put(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, target.trustStorePassword().orElseThrow(IllegalArgumentException::new));
         });
 
         consumerConfig.putAll(config);

--- a/chutney/action-impl/src/test/java/com/chutneytesting/action/kafka/EmbeddedKafkaBasicConsumeActionIntegrationTest.java
+++ b/chutney/action-impl/src/test/java/com/chutneytesting/action/kafka/EmbeddedKafkaBasicConsumeActionIntegrationTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017-2023 Enedis
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chutneytesting.action.kafka;
+
+import org.junit.jupiter.api.AfterAll;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
+import org.springframework.kafka.test.EmbeddedKafkaZKBroker;
+
+public class EmbeddedKafkaBasicConsumeActionIntegrationTest extends KafkaBasicConsumeActionIntegrationTest {
+
+    private static EmbeddedKafkaBroker embeddedKafkaBroker;
+    @Override
+    protected String initBroker() {
+        embeddedKafkaBroker = new EmbeddedKafkaZKBroker(1);
+        embeddedKafkaBroker.afterPropertiesSet();
+        return embeddedKafkaBroker.getBrokersAsString();
+    }
+
+    @AfterAll
+    public static void afterAll() {
+        producer.close();
+        embeddedKafkaBroker.destroy();
+    }
+}

--- a/chutney/action-impl/src/test/java/com/chutneytesting/action/kafka/KafkaBasicConsumeActionIntegrationTest.java
+++ b/chutney/action-impl/src/test/java/com/chutneytesting/action/kafka/KafkaBasicConsumeActionIntegrationTest.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2017-2023 Enedis
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chutneytesting.action.kafka;
+
+import static com.chutneytesting.action.kafka.KafkaBasicConsumeAction.OUTPUT_BODY;
+import static com.chutneytesting.action.kafka.KafkaBasicConsumeAction.OUTPUT_BODY_HEADERS_KEY;
+import static com.chutneytesting.action.kafka.KafkaBasicConsumeAction.OUTPUT_BODY_PAYLOAD_KEY;
+import static com.chutneytesting.action.kafka.KafkaBasicConsumeAction.OUTPUT_HEADERS;
+import static com.chutneytesting.action.kafka.KafkaBasicConsumeAction.OUTPUT_PAYLOADS;
+import static com.chutneytesting.action.spi.ActionExecutionResult.Status.Failure;
+import static com.chutneytesting.action.spi.ActionExecutionResult.Status.Success;
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.kafka.test.utils.KafkaTestUtils.getCurrentOffset;
+import static org.springframework.util.MimeTypeUtils.TEXT_PLAIN_VALUE;
+
+import com.chutneytesting.action.TestLogger;
+import com.chutneytesting.action.TestTarget;
+import com.chutneytesting.action.http.HttpsServerStartActionTest;
+import com.chutneytesting.action.spi.Action;
+import com.chutneytesting.action.spi.ActionExecutionResult;
+import com.chutneytesting.action.spi.injectable.Target;
+import java.net.URISyntaxException;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.IntStream;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.IntegerSerializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.test.EmbeddedKafkaZKBroker;
+import org.springframework.kafka.test.utils.KafkaTestUtils;
+
+public class KafkaBasicConsumeActionIntegrationTest {
+
+    private static final String TOPIC = "topic";
+    private static final String GROUP = "mygroup";
+    private static String KEYSTORE_JKS;
+    private EmbeddedKafkaZKBroker embeddedKafkaBroker;
+
+    private Producer<Integer, String> producer;
+    private TestTarget.TestTargetBuilder targetBuilder;
+
+    private TestLogger logger;
+
+    @BeforeAll
+    static void beforeAll() throws URISyntaxException {
+        KEYSTORE_JKS = Paths.get(requireNonNull(HttpsServerStartActionTest.class.getResource("/security/server.jks")).toURI()).toAbsolutePath().toString();
+    }
+
+    @BeforeEach
+    public void before() {
+        logger = new TestLogger();
+        embeddedKafkaBroker = new EmbeddedKafkaZKBroker(1, false, TOPIC);
+        embeddedKafkaBroker.afterPropertiesSet();
+        producer = createProducer();
+        targetBuilder = TestTarget.TestTargetBuilder.builder().withTargetId("kafka").withUrl("tcp://" + embeddedKafkaBroker.getBrokersAsString());
+    }
+
+    @AfterEach
+    void tearDown() {
+        producer.close();
+        embeddedKafkaBroker.destroy();
+    }
+
+    @Test
+    public void should_consume_message_from_broker_without_truststore() {
+
+        // given
+        producer.send(new ProducerRecord<>(TOPIC, 123, "my-test-value"));
+
+        Map<String, String> props = new HashMap<>();
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, GROUP);
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, OffsetResetStrategy.EARLIEST.name().toLowerCase());
+
+        Action sut = new KafkaBasicConsumeAction(targetBuilder.build(), TOPIC, GROUP, props, 1, null, null, TEXT_PLAIN_VALUE, "10 s", null, null, logger);
+
+
+        // when
+        ActionExecutionResult actionExecutionResult = sut.execute();
+
+        // then
+        assertThat(actionExecutionResult.status).isEqualTo(Success);
+        List<Map<String, Object>> body = assertActionOutputsSize(actionExecutionResult, 1);
+        assertThat(body.get(0).get("payload")).isEqualTo("my-test-value");
+    }
+
+    @Test
+    public void consumer_from_target_with_truststore_should_reject_ssl_connection_with_broker_without_truststore_configured() {
+        // given
+        Target target = targetBuilder.withProperty("trustStore", KEYSTORE_JKS)
+            .withProperty("trustStorePassword", "server")
+            .withProperty("security.protocol", "SSL")
+            .build();
+
+        Map<String, String> props = new HashMap<>();
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, GROUP);
+
+        Action sut = new KafkaBasicConsumeAction(target, TOPIC, GROUP, props, 1, null, null, TEXT_PLAIN_VALUE, "3000 ms", null, null,logger);
+
+        // when
+        ActionExecutionResult actionExecutionResult = sut.execute();
+
+        // then
+        assertThat(actionExecutionResult.status).isEqualTo(Failure);
+
+    }
+
+    @Test
+    public void should_reset_offset_to_the_beginning() {
+        // given
+        Map<String, String> props = new HashMap<>();
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, GROUP);
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, OffsetResetStrategy.EARLIEST.name().toLowerCase());
+
+        Action sut = new KafkaBasicConsumeAction(targetBuilder.build(), TOPIC, GROUP, props, 1, null, null, TEXT_PLAIN_VALUE, "3000 ms", null,null, logger);
+
+        producer.send(new ProducerRecord<>(TOPIC, 123, "1"));
+
+
+        ActionExecutionResult actionExecutionResult = sut.execute();
+        assertThat(actionExecutionResult.status).isEqualTo(Success);
+        List<Map<String, Object>> body = assertActionOutputsSize(actionExecutionResult, 1);
+        assertThat(body.get(0).get("payload")).isEqualTo("1");
+
+        // second time
+        sut = new KafkaBasicConsumeAction(targetBuilder.build(), TOPIC, GROUP, props, 1, null, null, TEXT_PLAIN_VALUE, "3000 ms", null, null,logger);
+        actionExecutionResult = sut.execute();
+
+        assertThat(actionExecutionResult.status).isEqualTo(Failure);
+
+        // third time with reset
+        sut = new KafkaBasicConsumeAction(targetBuilder.build(), TOPIC, GROUP, props, 1, null, null, TEXT_PLAIN_VALUE, "3000 ms", null, true,logger);
+        actionExecutionResult = sut.execute();
+
+        assertThat(actionExecutionResult.status).isEqualTo(Success);
+        body = assertActionOutputsSize(actionExecutionResult, 1);
+        assertThat(body.get(0).get("payload")).isEqualTo("1");
+
+        // third time without reset
+        sut = new KafkaBasicConsumeAction(targetBuilder.build(), TOPIC, GROUP, props, 1, null, null, TEXT_PLAIN_VALUE, "3000 ms", null,null, logger);
+        actionExecutionResult = sut.execute();
+
+        assertThat(actionExecutionResult.status).isEqualTo(Failure);
+
+    }
+
+    private List<Map<String, Object>> assertActionOutputsSize(ActionExecutionResult actionExecutionResult, int size) {
+        assertThat(actionExecutionResult.outputs).hasSize(3);
+
+        final List<Map<String, Object>> body = (List<Map<String, Object>>) actionExecutionResult.outputs.get(OUTPUT_BODY);
+        final List<Map<String, Object>> payloads = (List<Map<String, Object>>) actionExecutionResult.outputs.get(OUTPUT_PAYLOADS);
+        final List<Map<String, Object>> headers = (List<Map<String, Object>>) actionExecutionResult.outputs.get(OUTPUT_HEADERS);
+        assertThat(body).hasSize(size);
+        assertThat(payloads).hasSize(size);
+        assertThat(headers).hasSize(size);
+
+        Map<String, Object> bodyTmp;
+        for (int i = 0; i < body.size(); i++) {
+            bodyTmp = body.get(i);
+            assertThat(bodyTmp.get(OUTPUT_BODY_PAYLOAD_KEY)).isEqualTo(payloads.get(i));
+            assertThat(bodyTmp.get(OUTPUT_BODY_HEADERS_KEY)).isEqualTo(headers.get(i));
+        }
+
+        return body;
+    }
+
+    private Producer<Integer, String> createProducer() {
+        Map<String, Object> producerProps = new HashMap<>(KafkaTestUtils.producerProps(embeddedKafkaBroker));
+        return new DefaultKafkaProducerFactory<>(producerProps, new IntegerSerializer(), new StringSerializer()).createProducer();
+    }
+}

--- a/chutney/action-impl/src/test/java/com/chutneytesting/action/kafka/KafkaBasicConsumeActionIntegrationTest.java
+++ b/chutney/action-impl/src/test/java/com/chutneytesting/action/kafka/KafkaBasicConsumeActionIntegrationTest.java
@@ -46,7 +46,6 @@ import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.serialization.IntegerSerializer;
 import org.apache.kafka.common.serialization.StringSerializer;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.kafka.core.DefaultKafkaProducerFactory;
@@ -159,7 +158,7 @@ public abstract class KafkaBasicConsumeActionIntegrationTest {
     }
 
     private KafkaBasicConsumeAction getKafkaBasicConsumeAction(Target target, Map<String, String> props, boolean resetOffset) {
-        return new KafkaBasicConsumeAction(target, uniqueTopic, GROUP, props, 1, null, null, TEXT_PLAIN_VALUE, "3000 ms", null, resetOffset, logger);
+        return new KafkaBasicConsumeAction(target, uniqueTopic, GROUP, props, 1, null, null, TEXT_PLAIN_VALUE, "10 s", null, resetOffset, logger);
     }
 
     private List<Map<String, Object>> assertActionOutputsSize(ActionExecutionResult actionExecutionResult, int size) {

--- a/kotlin-dsl/dsl/src/main/kotlin/com/chutneytesting/kotlin/dsl/ChutneyActionExtensions.kt
+++ b/kotlin-dsl/dsl/src/main/kotlin/com/chutneytesting/kotlin/dsl/ChutneyActionExtensions.kt
@@ -1815,7 +1815,7 @@ fun ChutneyStepBuilder.KafkaBasicConsumeAction(
     headerSelector: String? = null,
     contentType: String? = null,
     ackMode: KafkaSpringOffsetCommitBehavior? = null,
-    resetOffset: Boolean? = false,
+    resetOffset: Boolean = false,
     outputs: Map<String, Any> = mapOf(),
     validations: Map<String, Any> = mapOf(),
     strategy: Strategy? = null

--- a/kotlin-dsl/dsl/src/main/kotlin/com/chutneytesting/kotlin/dsl/ChutneyActionExtensions.kt
+++ b/kotlin-dsl/dsl/src/main/kotlin/com/chutneytesting/kotlin/dsl/ChutneyActionExtensions.kt
@@ -1815,6 +1815,7 @@ fun ChutneyStepBuilder.KafkaBasicConsumeAction(
     headerSelector: String? = null,
     contentType: String? = null,
     ackMode: KafkaSpringOffsetCommitBehavior? = null,
+    resetOffset: Boolean? = false,
     outputs: Map<String, Any> = mapOf(),
     validations: Map<String, Any> = mapOf(),
     strategy: Strategy? = null
@@ -1831,7 +1832,8 @@ fun ChutneyStepBuilder.KafkaBasicConsumeAction(
             "nb-messages" to nbMessages,
             "header-selector" to headerSelector,
             "content-type" to contentType,
-            "ackMode" to ackMode
+            "ackMode" to ackMode,
+            "resetOffset" to resetOffset
         ).notEmptyToMap(),
         outputs = outputs,
         validations = validations

--- a/kotlin-dsl/dsl/src/test/kotlin/com/chutneytesting/kotlin/dsl/ChutneyScenarioDslTest.kt
+++ b/kotlin-dsl/dsl/src/test/kotlin/com/chutneytesting/kotlin/dsl/ChutneyScenarioDslTest.kt
@@ -197,7 +197,8 @@ class ChutneyScenarioDslTest {
                     nbMessages = 2,
                     headerSelector = "$[json/path]",
                     contentType = "application/json",
-                    ackMode = KafkaSpringOffsetCommitBehavior.MANUAL
+                    ackMode = KafkaSpringOffsetCommitBehavior.MANUAL,
+                    resetOffset = true
                 )
             }
         }

--- a/kotlin-dsl/dsl/src/test/resources/dsl/kafka-actions.chutney.json
+++ b/kotlin-dsl/dsl/src/test/resources/dsl/kafka-actions.chutney.json
@@ -30,7 +30,8 @@
                     "nb-messages": 2,
                     "header-selector": "$[json/path]",
                     "content-type": "application/json",
-                    "ackMode": "MANUAL"
+                    "ackMode": "MANUAL",
+                    "resetOffset": true
                 }
             }
         }


### PR DESCRIPTION
#### Issue Number
fixes #
<!-- Please Mention the issue number as #(Issue Number) Example: #5 -->

#### Describe the changes you've made
When consuming from kafka with`resetOffset=true`, the group offset is reset to the beginning.

<!-- A clear and concise description of what you have done to successfully close the issue.
Any new files? or anything you feel to let us know! -->

#### Describe if there is any unusual behaviour of your code <!-- Write `NA` if there isn't -->

<!-- A clear and concise description of it. -->

#### Additional context <!-- OPTIONAL -->

<!-- Add any other context or screenshots about the feature request here -->

#### Test plan <!-- OPTIONAL -->

<!-- A good test plan should give instructions that someone else can easily follow.
How someone can test your code? -->

#### Checklist

<!-- To tick a checkbox, replace the whitespace by the letter 'x' such as: [x] -->

- [ ] Refer to issue(s) the PR solves
- [x] New java code is covered by tests
- [ ] Add screenshots or gifs of the new behavior, if applicable.
- [x] All new and existing tests pass
- [x] No git conflict
