### PR TITLE
Fix startNotify called already excpetion on json execution

### DIFF
--- a/idea-plugin/src/main/kotlin/com/chutneytesting/idea/runner/ChutneyJsonToTestEventConverter.kt
+++ b/idea-plugin/src/main/kotlin/com/chutneytesting/idea/runner/ChutneyJsonToTestEventConverter.kt
@@ -43,7 +43,7 @@ class ChutneyJsonToTestEventConverter(
         ApplicationManager.getApplication().executeOnPooledThread {
             val server = ChutneyServerRegistry.instance.myServer
             WaitUntilUtils.waitUntil({ getServerUrl(server) != null }, 60000)
-            processHandler.startNotify()
+            //processHandler.startNotify()
             val cacheEvaluation = mutableMapOf<Int, Any>()
             jsonFiles.filterNotNull().forEachIndexed { index, virtualFile ->
                 if (ChutneyUtil.isChutneyDsl(virtualFile)) {


### PR DESCRIPTION
#### Checklist

- [ ] Refer to issue(s) the PR solves
- [ ] New java code is covered by tests
- [ ] Add screenshots or gifs of the new behavior, if applicable.
- [x] All new and existing tests pass
- [x] No git conflict
