### PR TITLE
Campaign execution with scenario-dataset pair

### DIFF
--- a/chutney/server-core/src/main/java/com/chutneytesting/server/core/domain/scenario/campaign/CampaignExecution.java
+++ b/chutney/server-core/src/main/java/com/chutneytesting/server/core/domain/scenario/campaign/CampaignExecution.java
@@ -183,10 +183,6 @@ public class CampaignExecution {
         }
     }
 
-    public ServerReportStatus getStatus() {
-        return status;
-    }
-
     public List<ScenarioExecutionCampaign> scenarioExecutionReports() {
         if (findStatus(scenarioExecutions).isFinal()) {
             scenarioExecutions.sort(ScenarioExecutionCampaign.executionIdComparator());
@@ -244,7 +240,7 @@ public class CampaignExecution {
         return scenarioExecutionReports.stream()
             .filter(Objects::nonNull)
             .collect(Collectors.toMap(
-                ScenarioExecutionCampaign::scenarioId,
+                Function.identity(),
                 Function.identity(),
                 BinaryOperator.maxBy(Comparator.comparing(s -> s.execution().time())),
                 LinkedHashMap::new // Keep the insertion order

--- a/chutney/server/src/main/java/com/chutneytesting/campaign/api/dto/ScenarioExecutionReportOutlineDto.java
+++ b/chutney/server/src/main/java/com/chutneytesting/campaign/api/dto/ScenarioExecutionReportOutlineDto.java
@@ -16,10 +16,14 @@
 
 package com.chutneytesting.campaign.api.dto;
 
+import static java.util.Collections.emptySet;
+
 import com.chutneytesting.server.core.domain.execution.history.ExecutionHistory;
 import com.chutneytesting.server.core.domain.execution.report.ServerReportStatus;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.Set;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ScenarioExecutionReportOutlineDto {
@@ -37,6 +41,10 @@ public class ScenarioExecutionReportOutlineDto {
 
     public String getScenarioId() {
         return scenarioId;
+    }
+
+    public Optional<String> getDatasetId() {
+        return execution.datasetId();
     }
 
     public Long getExecutionId() {
@@ -65,6 +73,10 @@ public class ScenarioExecutionReportOutlineDto {
 
     public String getError() {
         return execution.error().orElse("");
+    }
+
+    public Set<String> getTags() {
+        return execution.tags().orElse(emptySet());
     }
 
     ExecutionHistory.ExecutionSummary getExecution() {

--- a/chutney/server/src/main/java/com/chutneytesting/campaign/infra/DatabaseCampaignRepository.java
+++ b/chutney/server/src/main/java/com/chutneytesting/campaign/infra/DatabaseCampaignRepository.java
@@ -131,6 +131,7 @@ public class DatabaseCampaignRepository implements CampaignRepository {
 
         return campaignScenarioJpaRepository.findAllByScenarioId(scenarioId).stream()
             .map(CampaignScenarioEntity::campaign)
+            .distinct()
             .map(CampaignEntity::toDomain)
             .toList();
     }

--- a/chutney/server/src/main/java/com/chutneytesting/campaign/infra/jpa/CampaignExecutionEntity.java
+++ b/chutney/server/src/main/java/com/chutneytesting/campaign/infra/jpa/CampaignExecutionEntity.java
@@ -124,7 +124,7 @@ public class CampaignExecutionEntity {
                 scenarioExecutionCampaigns = campaign.campaignScenarios().stream()
                     .map(cs ->
                         scenarioExecutions.stream()
-                            .filter(se -> se.scenarioId().equals(cs.scenarioId()))
+                            .filter(se -> se.scenarioId().equals(cs.scenarioId()) && ofNullable(se.datasetId()).equals(ofNullable(cs.datasetId())))
                             .findFirst()
                             .map(se -> new ScenarioExecutionCampaign(se.scenarioId(), se.scenarioTitle(), se.toDomain()))
                             .orElseGet(() -> blankScenarioExecutionReport(cs, scenarioTitleSupplier)))

--- a/chutney/server/src/main/java/com/chutneytesting/execution/api/CampaignExecutionApiMapper.java
+++ b/chutney/server/src/main/java/com/chutneytesting/execution/api/CampaignExecutionApiMapper.java
@@ -19,11 +19,13 @@ package com.chutneytesting.execution.api;
 import com.chutneytesting.server.core.domain.scenario.campaign.CampaignExecution;
 import java.util.Optional;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 import org.mapstruct.ReportingPolicy;
 
 @Mapper(componentModel = "spring", unmappedSourcePolicy = ReportingPolicy.IGNORE)
 public interface CampaignExecutionApiMapper {
-    CampaignExecutionReportSummaryDto toCompaignExecutionReportSummaryDto(CampaignExecution campaignExecution);
+    @Mapping(expression = "java( campaignExecution.status() )", target = "status")
+    CampaignExecutionReportSummaryDto toCampaignExecutionReportSummaryDto(CampaignExecution campaignExecution);
 
     default String mapOptionalString(Optional<String> value) {
         return value.orElse(null);

--- a/chutney/server/src/main/java/com/chutneytesting/execution/api/CampaignExecutionApiMapper.java
+++ b/chutney/server/src/main/java/com/chutneytesting/execution/api/CampaignExecutionApiMapper.java
@@ -16,18 +16,25 @@
 
 package com.chutneytesting.execution.api;
 
+import com.chutneytesting.server.core.domain.execution.report.ServerReportStatus;
 import com.chutneytesting.server.core.domain.scenario.campaign.CampaignExecution;
 import java.util.Optional;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.Named;
 import org.mapstruct.ReportingPolicy;
 
 @Mapper(componentModel = "spring", unmappedSourcePolicy = ReportingPolicy.IGNORE)
 public interface CampaignExecutionApiMapper {
-    @Mapping(expression = "java( campaignExecution.status() )", target = "status")
+    @Mapping(target = "status", source = ".", qualifiedByName = "mapStatus")
     CampaignExecutionReportSummaryDto toCampaignExecutionReportSummaryDto(CampaignExecution campaignExecution);
 
     default String mapOptionalString(Optional<String> value) {
         return value.orElse(null);
+    }
+
+    @Named("mapStatus")
+    default ServerReportStatus mapStatus(CampaignExecution campaignExecution) {
+        return campaignExecution.status();
     }
 }

--- a/chutney/server/src/main/java/com/chutneytesting/execution/api/CampaignExecutionUiController.java
+++ b/chutney/server/src/main/java/com/chutneytesting/execution/api/CampaignExecutionUiController.java
@@ -71,7 +71,7 @@ public class CampaignExecutionUiController {
     @GetMapping(path = {"/{campaignName}/lastExecution", "/{campaignName}/{env}/lastExecution"}, produces = MediaType.APPLICATION_JSON_VALUE)
     public CampaignExecutionReportSummaryDto getLastCampaignExecution(@PathVariable("campaignId") Long campaignId) {
         CampaignExecution lastCampaignExecution = campaignExecutionEngine.getLastCampaignExecution(campaignId);
-        return campaignExecutionApiMapper.toCompaignExecutionReportSummaryDto(lastCampaignExecution);
+        return campaignExecutionApiMapper.toCampaignExecutionReportSummaryDto(lastCampaignExecution);
     }
 
 

--- a/chutney/server/src/main/java/com/chutneytesting/execution/domain/purge/PurgeServiceImpl.java
+++ b/chutney/server/src/main/java/com/chutneytesting/execution/domain/purge/PurgeServiceImpl.java
@@ -141,7 +141,7 @@ public class PurgeServiceImpl implements PurgeService {
             isExecutionDateBeforeNowMinusOffset(cer -> cer.startDate, beforeHoursTimeExecutions),
             cer -> cer.executionId,
             cer -> cer.startDate,
-            CampaignExecution::getStatus,
+            CampaignExecution::status,
             cer -> cer.executionEnvironment,
             campaignExecutionRepository::deleteExecutions
         ) {

--- a/chutney/server/src/test/java/com/chutneytesting/campaign/api/CampaignControllerTest.java
+++ b/chutney/server/src/test/java/com/chutneytesting/campaign/api/CampaignControllerTest.java
@@ -33,6 +33,7 @@ import com.chutneytesting.WebConfiguration;
 import com.chutneytesting.campaign.api.dto.CampaignDto;
 import com.chutneytesting.campaign.api.dto.CampaignDto.CampaignScenarioDto;
 import com.chutneytesting.campaign.api.dto.CampaignExecutionReportDto;
+import com.chutneytesting.campaign.api.dto.ScenarioExecutionReportOutlineDto;
 import com.chutneytesting.campaign.domain.CampaignService;
 import com.chutneytesting.campaign.infra.FakeCampaignRepository;
 import com.chutneytesting.scenario.api.raw.dto.ImmutableTestCaseIndexDto;
@@ -40,10 +41,12 @@ import com.chutneytesting.scenario.api.raw.dto.TestCaseIndexDto;
 import com.chutneytesting.scenario.infra.TestCaseRepositoryAggregator;
 import com.chutneytesting.server.core.domain.execution.history.ExecutionHistory;
 import com.chutneytesting.server.core.domain.execution.history.ExecutionHistoryRepository;
+import com.chutneytesting.server.core.domain.execution.report.ServerReportStatus;
 import com.chutneytesting.server.core.domain.instrument.ChutneyMetrics;
 import com.chutneytesting.server.core.domain.scenario.TestCaseMetadataImpl;
 import com.chutneytesting.server.core.domain.scenario.campaign.CampaignExecution;
 import com.chutneytesting.server.core.domain.scenario.campaign.ScenarioExecutionCampaign;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
@@ -428,7 +431,14 @@ public class CampaignControllerTest {
         }
 
         private CampaignExecutionReportDto[] reports() throws IOException {
-            return om.readValue(content(), CampaignExecutionReportDto[].class);
+            return om.readValue(content(), CampaignExecutionReportDtoTest[].class);
+        }
+    }
+
+    @JsonIgnoreProperties("scenarioExecutionReports")
+    static class CampaignExecutionReportDtoTest extends CampaignExecutionReportDto {
+        public CampaignExecutionReportDtoTest(Long executionId, List<ScenarioExecutionReportOutlineDto> scenarioExecutionReports, String campaignName, LocalDateTime startDate, ServerReportStatus status, boolean partialExecution, String executionEnvironment, String userId, Long duration) {
+            super(executionId, scenarioExecutionReports, campaignName, startDate, status, partialExecution, executionEnvironment, userId, duration);
         }
     }
 }

--- a/chutney/server/src/test/java/com/chutneytesting/campaign/domain/CampaignExecutionTest.java
+++ b/chutney/server/src/test/java/com/chutneytesting/campaign/domain/CampaignExecutionTest.java
@@ -47,202 +47,215 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.IntStream;
 import org.assertj.core.util.Lists;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-public class CampaignExecutionTest {
+class CampaignExecutionTest {
 
-    @Test
-    public void should_take_the_earliest_scenario_start_date_as_start_date() {
-        // Given
-        ScenarioExecutionCampaign execution_noTime = new ScenarioExecutionCampaign("1", "...", mock(ExecutionHistory.ExecutionSummary.class));
+    @Nested
+    @DisplayName("Execution construction")
+    class Instantiation {
 
-        ExecutionHistory.ExecutionSummary execution_5mn = mock(ExecutionHistory.ExecutionSummary.class);
-        when(execution_5mn.time()).thenReturn(LocalDateTime.now().minusMinutes(5));
-        ScenarioExecutionCampaign scenarioReport_5mn = new ScenarioExecutionCampaign("2", "...", execution_5mn);
+        @Test
+        void take_the_earliest_scenario_start_date_as_start_date() {
+            // Given
+            ScenarioExecutionCampaign execution_noTime = new ScenarioExecutionCampaign("1", "...", mock(ExecutionHistory.ExecutionSummary.class));
 
-        ExecutionHistory.ExecutionSummary execution_2mn = mock(ExecutionHistory.ExecutionSummary.class);
-        when(execution_2mn.time()).thenReturn(LocalDateTime.now().minusMinutes(2));
-        ScenarioExecutionCampaign scenarioReport_2mn = new ScenarioExecutionCampaign("3", "...", execution_2mn);
+            ExecutionHistory.ExecutionSummary execution_5mn = mock(ExecutionHistory.ExecutionSummary.class);
+            when(execution_5mn.time()).thenReturn(LocalDateTime.now().minusMinutes(5));
+            ScenarioExecutionCampaign scenarioReport_5mn = new ScenarioExecutionCampaign("2", "...", execution_5mn);
 
-        // When
-        CampaignExecution campaignReport = new CampaignExecution(1L, 1L, Lists.list(execution_noTime, scenarioReport_5mn, scenarioReport_2mn), "...", false, "", null, "");
+            ExecutionHistory.ExecutionSummary execution_2mn = mock(ExecutionHistory.ExecutionSummary.class);
+            when(execution_2mn.time()).thenReturn(LocalDateTime.now().minusMinutes(2));
+            ScenarioExecutionCampaign scenarioReport_2mn = new ScenarioExecutionCampaign("3", "...", execution_2mn);
 
-        // Then
-        assertThat(campaignReport.startDate).isEqualTo(execution_5mn.time());
+            // When
+            CampaignExecution campaignReport = new CampaignExecution(1L, 1L, Lists.list(execution_noTime, scenarioReport_5mn, scenarioReport_2mn), "...", false, "", null, "");
+
+            // Then
+            assertThat(campaignReport.startDate).isEqualTo(execution_5mn.time());
+        }
+
+        @Test
+        void set_start_date_as_min_possible_date_when_no_scenario_times_are_available() {
+            // Given
+            ScenarioExecutionCampaign scenarioReport1 = new ScenarioExecutionCampaign("1", "...", mock(ExecutionHistory.ExecutionSummary.class));
+            ScenarioExecutionCampaign scenarioReport2 = new ScenarioExecutionCampaign("2", "...", mock(ExecutionHistory.ExecutionSummary.class));
+
+            // When
+            CampaignExecution campaignReport = new CampaignExecution(1L, 1L, Lists.list(scenarioReport1, scenarioReport2), "...", false, "", null, "");
+
+            // Then
+            assertThat(campaignReport.startDate).isEqualTo(LocalDateTime.MIN);
+        }
+
+        @Test
+        void start_campaign_execution_when_no_scenario_reports() {
+            // When
+            LocalDateTime beforeInstanciation = LocalDateTime.now().minusSeconds(1);
+            CampaignExecution campaignReport = new CampaignExecution(1L, "...", false, "", null, "");
+            // Then
+            assertThat(campaignReport.startDate).isAfter(beforeInstanciation);
+            assertThat(campaignReport.status()).isEqualTo(RUNNING);
+        }
+
+        @Test
+        void set_status_when_empty_scenario_reports() {
+            // When
+            CampaignExecution campaignReport = new CampaignExecution(1L, 1L, emptyList(), "...", false, "", null, "");
+            // Then
+            assertThat(campaignReport.status()).isEqualTo(SUCCESS);
+        }
+
+        @Test
+        void set_to_worst_status_when_scenario_reports() {
+            // Given
+            ScenarioExecutionCampaign execution_noStatus = new ScenarioExecutionCampaign("1", "...", mock(ExecutionHistory.ExecutionSummary.class));
+
+            ExecutionHistory.ExecutionSummary execution_SUCESS = mock(ExecutionHistory.ExecutionSummary.class);
+            when(execution_SUCESS.status()).thenReturn(SUCCESS);
+            ScenarioExecutionCampaign scenarioReport_SUCCESS = new ScenarioExecutionCampaign("2", "...", execution_SUCESS);
+
+            ExecutionHistory.ExecutionSummary execution_FAILURE = mock(ExecutionHistory.ExecutionSummary.class);
+            when(execution_FAILURE.status()).thenReturn(FAILURE);
+            ScenarioExecutionCampaign scenarioReport_FAILURE = new ScenarioExecutionCampaign("3", "...", execution_FAILURE);
+            // When
+            CampaignExecution campaignReport = new CampaignExecution(1L, 1L, Lists.list(execution_noStatus, scenarioReport_SUCCESS, scenarioReport_FAILURE), "...", false, "", null, "");
+            // Then
+            assertThat(campaignReport.status()).isEqualTo(FAILURE);
+        }
     }
 
-    @Test
-    public void should_set_start_date_as_min_possible_date_when_no_scenario_times_are_available() {
-        // Given
-        ScenarioExecutionCampaign scenarioReport1 = new ScenarioExecutionCampaign("1", "...", mock(ExecutionHistory.ExecutionSummary.class));
-        ScenarioExecutionCampaign scenarioReport2 = new ScenarioExecutionCampaign("2", "...", mock(ExecutionHistory.ExecutionSummary.class));
+    @Nested
+    @DisplayName("Execution workflow")
+    class ExecutionWorkflow {
 
-        // When
-        CampaignExecution campaignReport = new CampaignExecution(1L, 1L, Lists.list(scenarioReport1, scenarioReport2), "...", false, "", null, "");
+        @Test
+        void start_scenario_execution() {
+            // Given
+            CampaignExecution campaignReport = new CampaignExecution(1L, "...", false, "", "#55:1", "user");
+            TestCase testCase = buildTestCase("1", "title");
+            LocalDateTime beforeStartExecution = LocalDateTime.now().minusSeconds(1);
 
-        // Then
-        assertThat(campaignReport.startDate).isEqualTo(LocalDateTime.MIN);
-    }
+            // When
+            campaignReport.initExecution(singletonList(new TestCaseDataset(testCase, null)), "env", "user");
 
-    @Test
-    public void should_start_campaign_execution_when_instantiate_with_no_scenario_reports() {
-        // When
-        LocalDateTime beforeInstanciation = LocalDateTime.now().minusSeconds(1);
-        CampaignExecution campaignReport = new CampaignExecution(1L, "...", false, "", null, "");
-        // Then
-        assertThat(campaignReport.startDate).isAfter(beforeInstanciation);
-        assertThat(campaignReport.status()).isEqualTo(RUNNING);
-    }
-
-    @Test
-    public void should_set_status_when_instantiate_with_empty_scenario_reports() {
-        // When
-        CampaignExecution campaignReport = new CampaignExecution(1L, 1L, emptyList(), "...", false, "", null, "");
-        // Then
-        assertThat(campaignReport.status()).isEqualTo(SUCCESS);
-    }
-
-    @Test
-    public void should_set_to_worst_status_when_instantiate_with_scenario_reports() {
-        // Given
-        ScenarioExecutionCampaign execution_noStatus = new ScenarioExecutionCampaign("1", "...", mock(ExecutionHistory.ExecutionSummary.class));
-
-        ExecutionHistory.ExecutionSummary execution_SUCESS = mock(ExecutionHistory.ExecutionSummary.class);
-        when(execution_SUCESS.status()).thenReturn(SUCCESS);
-        ScenarioExecutionCampaign scenarioReport_SUCCESS = new ScenarioExecutionCampaign("2", "...", execution_SUCESS);
-
-        ExecutionHistory.ExecutionSummary execution_FAILURE = mock(ExecutionHistory.ExecutionSummary.class);
-        when(execution_FAILURE.status()).thenReturn(FAILURE);
-        ScenarioExecutionCampaign scenarioReport_FAILURE = new ScenarioExecutionCampaign("3", "...", execution_FAILURE);
-        // When
-        CampaignExecution campaignReport = new CampaignExecution(1L, 1L, Lists.list(execution_noStatus, scenarioReport_SUCCESS, scenarioReport_FAILURE), "...", false, "", null, "");
-        // Then
-        assertThat(campaignReport.status()).isEqualTo(FAILURE);
-    }
-
-    @Test
-    public void should_start_scenario_execution() {
-        // Given
-        CampaignExecution campaignReport = new CampaignExecution(1L, "...", false, "", "#55:1", "user");
-        TestCase testCase = buildTestCase("1", "title");
-        LocalDateTime beforeStartExecution = LocalDateTime.now().minusSeconds(1);
-
-        // When
-        campaignReport.initExecution(singletonList(new TestCaseDataset(testCase, null)), "env", "user");
-
-        // Then
-        assertThat(campaignReport.scenarioExecutionReports()).hasSize(1);
-        assertThat(campaignReport.scenarioExecutionReports().get(0)).satisfies(report -> {
-            assertThat(report.scenarioId()).isEqualTo(testCase.metadata().id());
-            assertThat(report.scenarioName()).isEqualTo(testCase.metadata().title());
-            assertThat(report.execution()).satisfies(executionSummary -> {
-                assertThat(executionSummary.executionId()).isEqualTo(-1L);
-                assertThat(executionSummary.time()).isAfter(beforeStartExecution);
-                assertThat(executionSummary.status()).isEqualTo(NOT_EXECUTED);
-                assertThat(executionSummary.environment()).isEqualTo("env");
-                assertThat(executionSummary.datasetId()).isEqualTo(campaignReport.dataSetId);
-                assertThat(executionSummary.user()).isEqualTo(campaignReport.userId);
+            // Then
+            assertThat(campaignReport.scenarioExecutionReports()).hasSize(1);
+            assertThat(campaignReport.scenarioExecutionReports().get(0)).satisfies(report -> {
+                assertThat(report.scenarioId()).isEqualTo(testCase.metadata().id());
+                assertThat(report.scenarioName()).isEqualTo(testCase.metadata().title());
+                assertThat(report.execution()).satisfies(executionSummary -> {
+                    assertThat(executionSummary.executionId()).isEqualTo(-1L);
+                    assertThat(executionSummary.time()).isAfter(beforeStartExecution);
+                    assertThat(executionSummary.status()).isEqualTo(NOT_EXECUTED);
+                    assertThat(executionSummary.environment()).isEqualTo("env");
+                    assertThat(executionSummary.datasetId()).isEqualTo(campaignReport.dataSetId);
+                    assertThat(executionSummary.user()).isEqualTo(campaignReport.userId);
+                });
             });
-        });
 
-        // When
-        campaignReport.startScenarioExecution(new TestCaseDataset(testCase, null), "env", "user");
+            // When
+            campaignReport.startScenarioExecution(new TestCaseDataset(testCase, null), "env", "user");
 
-        // Then
-        assertThat(campaignReport.scenarioExecutionReports()).hasSize(1);
-        assertThat(campaignReport.scenarioExecutionReports().get(0)).satisfies(report -> {
-            assertThat(report.scenarioId()).isEqualTo(testCase.metadata().id());
-            assertThat(report.scenarioName()).isEqualTo(testCase.metadata().title());
-            assertThat(report.execution()).satisfies(executionSummary -> {
-                assertThat(executionSummary.executionId()).isEqualTo(-1L);
-                assertThat(executionSummary.time()).isAfter(beforeStartExecution);
-                assertThat(executionSummary.status()).isEqualTo(RUNNING);
-                assertThat(executionSummary.environment()).isEqualTo("env");
-                assertThat(executionSummary.user()).isEqualTo(campaignReport.userId);
-                assertThat(executionSummary.datasetId()).isEqualTo(campaignReport.dataSetId);
+            // Then
+            assertThat(campaignReport.scenarioExecutionReports()).hasSize(1);
+            assertThat(campaignReport.scenarioExecutionReports().get(0)).satisfies(report -> {
+                assertThat(report.scenarioId()).isEqualTo(testCase.metadata().id());
+                assertThat(report.scenarioName()).isEqualTo(testCase.metadata().title());
+                assertThat(report.execution()).satisfies(executionSummary -> {
+                    assertThat(executionSummary.executionId()).isEqualTo(-1L);
+                    assertThat(executionSummary.time()).isAfter(beforeStartExecution);
+                    assertThat(executionSummary.status()).isEqualTo(RUNNING);
+                    assertThat(executionSummary.environment()).isEqualTo("env");
+                    assertThat(executionSummary.user()).isEqualTo(campaignReport.userId);
+                    assertThat(executionSummary.datasetId()).isEqualTo(campaignReport.dataSetId);
+                });
             });
-        });
+        }
+
+        @Test
+        void end_scenario_execution() {
+            // Given
+            CampaignExecution campaignReport = new CampaignExecution(1L, "...", false, "", null, "");
+            TestCase testCase = buildTestCase("1", "title");
+            var testcaseToExecute = new TestCaseDataset(testCase, null);
+            campaignReport.initExecution(singletonList(testcaseToExecute), "env", "user");
+            campaignReport.startScenarioExecution(testcaseToExecute, "env", "user");
+
+            ScenarioExecutionCampaign scenarioReport_SUCCESS = buildScenarioReportFromMockedExecution(testCase.id(), null, testCase.metadata().title(), SUCCESS);
+
+            // When
+            campaignReport.endScenarioExecution(scenarioReport_SUCCESS);
+
+            // Then
+            assertThat(campaignReport.scenarioExecutionReports()).hasSize(1);
+            assertThat(campaignReport.scenarioExecutionReports().get(0).execution().status()).isEqualTo(SUCCESS);
+        }
+
+        @Test
+        void compute_status_from_scenarios_when_end_campaign_execution() {
+            // Given
+            CampaignExecution campaignReport = new CampaignExecution(1L, "...", false, "", null, "");
+            addScenarioExecutions(campaignReport, "1", "title1", SUCCESS);
+            addScenarioExecutions(campaignReport, "2", "title2", FAILURE);
+
+            // When
+            campaignReport.endCampaignExecution();
+
+            // Then
+            assertThat(campaignReport.scenarioExecutionReports()).hasSize(2);
+            assertThat(campaignReport.status()).isEqualTo(FAILURE);
+        }
+
+        @Test
+        void compute_stop_final_status_when_having_not_executed_scenario() {
+            // Given
+            CampaignExecution campaignReport = new CampaignExecution(1L, "...", false, "", null, "");
+            addScenarioExecutions(campaignReport, "1", "title1", SUCCESS);
+            addScenarioExecutions(campaignReport, "2", "title2", NOT_EXECUTED);
+
+            // When
+            campaignReport.endCampaignExecution();
+
+            // Then
+            assertThat(campaignReport.scenarioExecutionReports()).hasSize(2);
+            assertThat(campaignReport.status()).isEqualTo(STOPPED);
+        }
     }
 
     @Test
-    public void should_end_scenario_execution() {
-        // Given
-        CampaignExecution campaignReport = new CampaignExecution(1L, "...", false, "", null, "");
-        TestCase testCase = buildTestCase("1", "title");
-        var testcaseToExecute = new TestCaseDataset(testCase, null);
-        campaignReport.initExecution(singletonList(testcaseToExecute), "env", "user");
-        campaignReport.startScenarioExecution(testcaseToExecute, "env", "user");
-
-        ScenarioExecutionCampaign scenarioReport_SUCCESS = buildScenarioReportFromMockedExecution(testCase.id(), null, testCase.metadata().title(), SUCCESS);
-
-        // When
-        campaignReport.endScenarioExecution(scenarioReport_SUCCESS);
-
-        // Then
-        assertThat(campaignReport.scenarioExecutionReports()).hasSize(1);
-        assertThat(campaignReport.scenarioExecutionReports().get(0).execution().status()).isEqualTo(SUCCESS);
-    }
-
-    @Test
-    public void should_compute_status_from_scenarios_when_end_campaign_execution() {
-        // Given
-        CampaignExecution campaignReport = new CampaignExecution(1L, "...", false, "", null, "");
-        addScenarioExecutions(campaignReport, "1", "title1", SUCCESS);
-        addScenarioExecutions(campaignReport, "2", "title2", FAILURE);
-
-        // When
-        campaignReport.endCampaignExecution();
-
-        // Then
-        assertThat(campaignReport.scenarioExecutionReports()).hasSize(2);
-        assertThat(campaignReport.status()).isEqualTo(FAILURE);
-    }
-
-    @Test
-    public void should_calculate_stop_final_status_when_having_not_executed_scenario() {
-        // Given
-        CampaignExecution campaignReport = new CampaignExecution(1L, "...", false, "", null, "");
-        addScenarioExecutions(campaignReport, "1", "title1", SUCCESS);
-        addScenarioExecutions(campaignReport, "2", "title2", NOT_EXECUTED);
-
-        // When
-        campaignReport.endCampaignExecution();
-
-        // Then
-        assertThat(campaignReport.scenarioExecutionReports()).hasSize(2);
-        assertThat(campaignReport.status()).isEqualTo(STOPPED);
-    }
-
-    @Test
-    public void should_calculate_filter_retry_scenario_in_status_calculation() {
+    void compute_status_without_retry_scenario_execution() {
         // Given
         String scenarioId = "1";
         ExecutionHistory.ExecutionSummary firstExecution = ImmutableExecutionHistory.ExecutionSummary.builder()
             .executionId(1L)
             .testCaseTitle("")
-            .time(LocalDateTime.now().minusMinutes(1l))
-            .duration(0l)
+            .time(LocalDateTime.now().minusMinutes(1L))
+            .duration(0L)
             .environment("")
             .user("")
             .status(FAILURE)
-            .scenarioId("")
+            .scenarioId(scenarioId)
             .build();
         ScenarioExecutionCampaign firstReport = new ScenarioExecutionCampaign(scenarioId, "", firstExecution);
         ExecutionHistory.ExecutionSummary retryExecution = ImmutableExecutionHistory.ExecutionSummary.builder()
             .executionId(2L)
             .testCaseTitle("")
             .time(LocalDateTime.now())
-            .duration(0l)
+            .duration(0L)
             .environment("")
             .user("")
             .status(SUCCESS)
-            .scenarioId("")
+            .scenarioId(scenarioId)
             .build();
         ScenarioExecutionCampaign retryReport = new ScenarioExecutionCampaign(scenarioId, "", retryExecution);
         CampaignExecution campaignReport = CampaignExecutionReportBuilder.builder()
             .addScenarioExecutionReport(firstReport)
             .addScenarioExecutionReport(retryReport)
             .build();
+
         // When
         ServerReportStatus status = campaignReport.status();
 
@@ -250,48 +263,52 @@ public class CampaignExecutionTest {
         assertThat(status).isEqualTo(SUCCESS);
     }
 
-    @Test
-    public void should_compute_duration_for_one_scenario_execution() {
-        LocalDateTime now = LocalDateTime.now();
-        long duration = 3;
+    @Nested
+    @DisplayName("Duration computation")
+    class Duration {
+        @Test
+        void for_one_scenario_execution() {
+            LocalDateTime now = LocalDateTime.now();
+            long duration = 3;
 
-        List<ScenarioExecutionCampaign> executions = stubScenarioExecution(singletonList(now), singletonList(duration));
-        CampaignExecution sut = fakeCampaignReport(executions);
+            List<ScenarioExecutionCampaign> executions = stubScenarioExecution(singletonList(now), singletonList(duration));
+            CampaignExecution sut = fakeCampaignReport(executions);
 
-        assertThat(sut.getDuration()).isEqualTo(3);
-    }
+            assertThat(sut.getDuration()).isEqualTo(3);
+        }
 
-    @Test
-    public void should_compute_duration_for_two_scenarios_sequential_executions() {
-        LocalDateTime now = LocalDateTime.now();
-        long duration1 = 3;
-        LocalDateTime scenarioExecutionStartDate2 = now.plus(duration1, ChronoUnit.MILLIS);
-        long duration2 = 6;
+        @Test
+        void for_two_scenarios_sequential_executions() {
+            LocalDateTime now = LocalDateTime.now();
+            long duration1 = 3;
+            LocalDateTime scenarioExecutionStartDate2 = now.plus(duration1, ChronoUnit.MILLIS);
+            long duration2 = 6;
 
-        List<ScenarioExecutionCampaign> executions =
-            stubScenarioExecution(
-                asList(now, scenarioExecutionStartDate2),
-                asList(duration1, duration2)
-            );
-        CampaignExecution sut = fakeCampaignReport(executions);
+            List<ScenarioExecutionCampaign> executions =
+                stubScenarioExecution(
+                    asList(now, scenarioExecutionStartDate2),
+                    asList(duration1, duration2)
+                );
+            CampaignExecution sut = fakeCampaignReport(executions);
 
-        assertThat(sut.getDuration()).isEqualTo(9);
-    }
+            assertThat(sut.getDuration()).isEqualTo(9);
+        }
 
-    @Test
-    public void should_compute_duration_for_two_scenarios_parallel_executions() {
-        LocalDateTime now = LocalDateTime.now();
-        long duration1 = 3;
-        long duration2 = 6;
+        @Test
+        void for_two_scenarios_parallel_executions() {
+            LocalDateTime now = LocalDateTime.now();
+            long duration1 = 3;
+            long duration2 = 6;
 
-        List<ScenarioExecutionCampaign> executions =
-            stubScenarioExecution(
-                asList(now, now),
-                asList(duration1, duration2)
-            );
-        CampaignExecution sut = fakeCampaignReport(executions);
+            List<ScenarioExecutionCampaign> executions =
+                stubScenarioExecution(
+                    asList(now, now),
+                    asList(duration1, duration2)
+                );
+            CampaignExecution sut = fakeCampaignReport(executions);
 
-        assertThat(sut.getDuration()).isEqualTo(6);
+            assertThat(sut.getDuration()).isEqualTo(6);
+        }
     }
 
     @Test
@@ -305,6 +322,20 @@ public class CampaignExecutionTest {
             .isInstanceOf(ScenarioExecutionCampaign.class)
             .hasFieldOrPropertyWithValue("scenarioId", "2")
             .returns(Optional.of("dataset_2"), sec -> sec.execution().datasetId());
+    }
+
+    @Test
+    void compute_execution_without_retries() {
+        CampaignExecution sut = new CampaignExecution(1L, "...", false, "", null, "");
+        addScenarioExecutions(sut, "1", "dataset_1", "", FAILURE);
+        addScenarioExecutions(sut, "1", "dataset_2", "", FAILURE);
+        var reportWithDataset1 = addScenarioExecutions(sut, "1", "dataset_1", "", SUCCESS);
+        var reportWithDataset2 = addScenarioExecutions(sut, "1", "dataset_2", "", SUCCESS);
+
+        CampaignExecution withoutRetries = sut.withoutRetries();
+
+        assertThat(withoutRetries.scenarioExecutionReports())
+            .containsExactly(reportWithDataset1, reportWithDataset2);
     }
 
     private List<ScenarioExecutionCampaign> stubScenarioExecution(List<LocalDateTime> times, List<Long> durations) {
@@ -326,7 +357,7 @@ public class CampaignExecutionTest {
         addScenarioExecutions(campaignReport, scenarioId, null, scenarioTitle, scenarioExecutionStatus);
     }
 
-    private void addScenarioExecutions(CampaignExecution campaignReport, String scenarioId, String datasetId, String scenarioTitle, ServerReportStatus scenarioExecutionStatus) {
+    private ScenarioExecutionCampaign addScenarioExecutions(CampaignExecution campaignReport, String scenarioId, String datasetId, String scenarioTitle, ServerReportStatus scenarioExecutionStatus) {
         TestCase testCase = buildTestCase(scenarioId, scenarioTitle);
         var testcaseToExecute = new TestCaseDataset(testCase, datasetId);
         campaignReport.initExecution(singletonList(testcaseToExecute), "", "");
@@ -337,12 +368,14 @@ public class CampaignExecutionTest {
         campaignReport.endScenarioExecution(scenarioReport);
 
         assertThat(campaignReport.status()).isEqualTo(RUNNING);
+        return scenarioReport;
     }
 
     private ScenarioExecutionCampaign buildScenarioReportFromMockedExecution(String scenarioId, String datasetId, String scenarioTitle, ServerReportStatus scenarioExecutionStatus) {
         ExecutionHistory.ExecutionSummary execution = mock(ExecutionHistory.ExecutionSummary.class);
         when(execution.status()).thenReturn(scenarioExecutionStatus);
         when(execution.datasetId()).thenReturn(Optional.ofNullable(datasetId).filter(not(String::isBlank)));
+        when(execution.time()).thenReturn(LocalDateTime.now());
         return new ScenarioExecutionCampaign(scenarioId, scenarioTitle, execution);
     }
 

--- a/chutney/server/src/test/java/com/chutneytesting/campaign/infra/DatabaseCampaignRepositoryTest.java
+++ b/chutney/server/src/test/java/com/chutneytesting/campaign/infra/DatabaseCampaignRepositoryTest.java
@@ -16,6 +16,7 @@
 
 package com.chutneytesting.campaign.infra;
 
+import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -186,7 +187,7 @@ public class DatabaseCampaignRepositoryTest {
             ScenarioEntity s2 = givenScenario();
             ScenarioEntity s3 = givenScenario();
             ScenarioEntity s4 = givenScenario();
-            Campaign campaign1 = new Campaign(null, "campaignTestName1", "campaignDesc1", scenariosIds(s1, s2), "env", false, false, null, null);
+            Campaign campaign1 = new Campaign(null, "campaignTestName1", "campaignDesc1", scenariosIds(List.of(s1, s2, s1), asList("ds1", null, "ds2")), "env", false, false, null, null);
             Campaign campaign2 = new Campaign(null, "campaignTestName2", "campaignDesc2", scenariosIds(s2, s1), "env", false, false, null, null);
             Campaign campaign3 = new Campaign(null, "campaignTestName3", "campaignDesc3", scenariosIds(s1, s3), "env", false, false, null, null);
             Campaign campaign4 = new Campaign(null, "campaignTestName4", "campaignDesc4", scenariosIds(s3, s4), "env", false, false, null, null);

--- a/chutney/server/src/test/java/com/chutneytesting/campaign/infra/jpa/CampaignExecutionEntityTest.java
+++ b/chutney/server/src/test/java/com/chutneytesting/campaign/infra/jpa/CampaignExecutionEntityTest.java
@@ -1,0 +1,74 @@
+/*
+ *  Copyright 2017-2023 Enedis
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chutneytesting.campaign.infra.jpa;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.chutneytesting.execution.infra.storage.jpa.ScenarioExecutionEntity;
+import com.chutneytesting.server.core.domain.execution.report.ServerReportStatus;
+import com.chutneytesting.server.core.domain.scenario.campaign.CampaignExecution;
+import java.util.List;
+import java.util.function.Function;
+import org.junit.jupiter.api.Test;
+
+class CampaignExecutionEntityTest {
+    @Test
+    void map_to_domain_with_multiple_datasets_scenarios_executions_while_running() {
+        CampaignEntity campaign = mock(CampaignEntity.class);
+        when(campaign.campaignScenarios()).thenReturn(List.of(
+            new CampaignScenarioEntity(campaign, "1", "dataset1", 1),
+            new CampaignScenarioEntity(campaign, "1", "dataset2", 2),
+            new CampaignScenarioEntity(campaign, "2", "dataset3", 3),
+            new CampaignScenarioEntity(campaign, "2", "dataset4", 4)
+        ));
+        List<ScenarioExecutionEntity> scenarioExecutions = List.of(
+            buildScenarioExecution("1", ServerReportStatus.SUCCESS, "dataset1"),
+            buildScenarioExecution("1", ServerReportStatus.RUNNING, "dataset2"),
+            buildScenarioExecution("2", ServerReportStatus.NOT_EXECUTED, "dataset3"),
+            buildScenarioExecution("2", ServerReportStatus.NOT_EXECUTED, "dataset4")
+        );
+        CampaignExecutionEntity sut = new CampaignExecutionEntity(0L, 0L, scenarioExecutions, false, "", "", "", 0);
+
+        CampaignExecution actual = sut.toDomain(campaign, true, true, Function.identity());
+
+        assertThat(actual.scenarioExecutionReports()).hasSameSizeAs(scenarioExecutions).satisfies(ser -> {
+            assertThat(ser.get(0)).satisfies(se -> {
+                assertThat(se.scenarioId()).isEqualTo("1");
+                assertThat(se.execution().datasetId()).hasValue("dataset1");
+            });
+            assertThat(ser.get(1)).satisfies(se -> {
+                assertThat(se.scenarioId()).isEqualTo("1");
+                assertThat(se.execution().datasetId()).hasValue("dataset2");
+            });
+            assertThat(ser.get(2)).satisfies(se -> {
+                assertThat(se.scenarioId()).isEqualTo("2");
+                assertThat(se.execution().datasetId()).hasValue("dataset3");
+            });
+            assertThat(ser.get(3)).satisfies(se -> {
+                assertThat(se.scenarioId()).isEqualTo("2");
+                assertThat(se.execution().datasetId()).hasValue("dataset4");
+            });
+        });
+    }
+
+    private ScenarioExecutionEntity buildScenarioExecution(String scenarioId, ServerReportStatus status, String datasetId) {
+        return new ScenarioExecutionEntity(0L, scenarioId, null, 0L, 0L, status, "", "", "", "", "", datasetId, "", 0);
+    }
+}

--- a/chutney/server/src/test/java/util/infra/AbstractLocalDatabaseTest.java
+++ b/chutney/server/src/test/java/util/infra/AbstractLocalDatabaseTest.java
@@ -33,6 +33,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
 import java.util.Set;
+import java.util.stream.IntStream;
 import javax.sql.DataSource;
 import liquibase.Liquibase;
 import liquibase.database.jvm.JdbcConnection;
@@ -125,6 +126,12 @@ public abstract class AbstractLocalDatabaseTest {
 
     protected List<Campaign.CampaignScenario> scenariosIds(ScenarioEntity... scenarioEntities) {
         return Arrays.stream(scenarioEntities).map(ScenarioEntity::getId).map(id -> new Campaign.CampaignScenario(id.toString(), null)).toList();
+    }
+
+    protected List<Campaign.CampaignScenario> scenariosIds(List<ScenarioEntity> scenarioEntities, List<String> datasetIds) {
+        return IntStream.range(0, scenarioEntities.size())
+            .mapToObj(idx -> new Campaign.CampaignScenario(scenarioEntities.get(idx).getId().toString(), datasetIds.get(idx)))
+            .toList();
     }
 
     protected Set<String> defaultScenarioTags() {

--- a/chutney/ui/src/app/modules/campaign/components/execution/detail/campaign-execution.component.html
+++ b/chutney/ui/src/app/modules/campaign/components/execution/detail/campaign-execution.component.html
@@ -87,15 +87,21 @@
                         <span *ngIf="orderBy == 'status' && reverseOrder" class="fa fa-caret-down"></span>
                         <span *ngIf="orderBy == 'status' && !reverseOrder" class="fa fa-caret-up"></span>
                     </th>
-                    <th scope="col" class="filter w45" (click)="sortBy('scenarioName')">{{ 'campaigns.execution.scenarios.item.header.title' | translate }}
+                    <th scope="col" class="w45" (click)="sortBy('scenarioName')">{{ 'campaigns.execution.scenarios.item.header.title' | translate }}
                         <span *ngIf="orderBy == 'scenarioName' && reverseOrder" class="fa fa-caret-down"></span>
                         <span *ngIf="orderBy == 'scenarioName' && !reverseOrder" class="fa fa-caret-up"></span>
                     </th>
-                    <th scope="col" class="filter" (click)="sortBy('error')">{{ 'campaigns.execution.scenarios.item.header.error' | translate }}
+                    <th scope="col" (click)="sortBy('error')">{{ 'campaigns.execution.scenarios.item.header.error' | translate }}
                         <span *ngIf="orderBy == 'error' && reverseOrder" class="fa fa-caret-down"></span>
                         <span *ngIf="orderBy == 'error' && !reverseOrder" class="fa fa-caret-up"></span>
                     </th>
-                    <th scope="col" class="filter w8 text-center" (click)="sortBy('duration')">{{ 'campaigns.execution.scenarios.item.header.duration' | translate }}
+                    <th scope="col" class="w8 text-center">
+                        {{ 'campaigns.execution.scenarios.item.header.tags' | translate }}
+                    </th>
+                    <th scope="col" class="w8 text-center">
+                        {{ 'campaigns.execution.scenarios.item.header.dataset' | translate }}
+                    </th>
+                    <th scope="col" class="w8 text-center" (click)="sortBy('duration')">{{ 'campaigns.execution.scenarios.item.header.duration' | translate }}
                         <span *ngIf="orderBy == 'duration' && reverseOrder" class="fa fa-caret-down"></span>
                         <span *ngIf="orderBy == 'duration' && !reverseOrder" class="fa fa-caret-up"></span>
                     </th>
@@ -130,6 +136,22 @@
                     </td>
                     <td class="align-middle">
                         <span><small (click)="showMore[i]=!showMore[i]">{{ (!showMore[i] && scenarioReportOutline.error.length > 100) ? (scenarioReportOutline.error | slice:0:100) + " ..." : (scenarioReportOutline.error) }}</small></span>
+                    </td>
+                    <td class="text-center align-middle text-nowrap">
+                        <ng-container *ngIf="scenarioReportOutline.tags.length <= 3">
+                            <span *ngFor="let tag of scenarioReportOutline.tags" class="badge bg-primary">{{tag}}</span>
+                        </ng-container>
+                        <ng-container *ngIf="scenarioReportOutline.tags.length > 3">
+                            <span *ngFor="let tag of scenarioReportOutline.tags | slice:0:2" class="badge bg-primary">{{tag}}</span>
+                            <button type="button" class="badge bg-primary"
+                                    ngbPopover="{{scenarioReportOutline.tags}}" placement="left"
+                                    triggers="mouseenter:mouseleave" container="body">
+                                ...
+                            </button>
+                        </ng-container>
+                    </td>
+                    <td class="text-center align-middle text-nowrap">
+                        <span><small>{{ scenarioReportOutline.datasetId }}</small></span>
                     </td>
                     <td class="text-center align-middle text-nowrap">
                         <span><small>{{ scenarioReportOutline.duration | duration:'short' }}</small></span>

--- a/chutney/ui/src/assets/i18n/en.json
+++ b/chutney/ui/src/assets/i18n/en.json
@@ -220,6 +220,8 @@
                         "state": "Status",
                         "title": "Title",
                         "error": "Report",
+                        "tags": "Tags",
+                        "dataset": "Dataset",
                         "duration": "Duration",
                         "jiraStatus": "Jira status"
                     },

--- a/chutney/ui/src/assets/i18n/fr.json
+++ b/chutney/ui/src/assets/i18n/fr.json
@@ -220,6 +220,8 @@
                         "state": "Statut",
                         "title": "Titre",
                         "error": "Rapport",
+                        "tags": "Tags",
+                        "dataset": "Dataset",
                         "duration": "Durée",
                         "jiraStatus": "Statut Jira"
                     },


### PR DESCRIPTION
#### Describe the changes you've made

For a campaign with scenario-dataset pair (create from kotlin, not possible from ui) :
* Allow to follow a running execution
* Show report with tags and dataset used
* Fix the campaign list got for a scenario (scenario edition page)

#### Checklist

- [ ] Refer to issue(s) the PR solves
- [x] New java code is covered by tests
- [ ] Add screenshots or gifs of the new behavior, if applicable.
- [x] All new and existing tests pass
- [x] No git conflict
