### PR TITLE
fix(ui) : break long word in admin bdd search, fix overflow ng-multi…

### DIFF
--- a/chutney/ui/src/app/modules/campaign/components/create-campaign/campaign-edition.component.scss
+++ b/chutney/ui/src/app/modules/campaign/components/create-campaign/campaign-edition.component.scss
@@ -100,12 +100,3 @@ fieldset legend {
     min-width:200px;
     display: inline-block;
 }
-
-::ng-deep ng-multiselect-dropdown .multiselect-dropdown .dropdown-btn .selected-item-container .selected-item {
-    display: flex;
-    span {
-        text-overflow: ellipsis;
-        display: block;
-        overflow: hidden;
-    }
-}

--- a/chutney/ui/src/app/modules/campaign/components/execution/detail/campaign-execution.component.html
+++ b/chutney/ui/src/app/modules/campaign/components/execution/detail/campaign-execution.component.html
@@ -166,7 +166,7 @@
                   {{ scenarioReportOutline.scenarioName }}
                 </ng-container>
               </td>
-              <td class="align-middle">
+              <td class="align-middle text-break">
                 <span><small (click)="showMore[i]=!showMore[i]">{{ (!showMore[i] && scenarioReportOutline.error.length > 100) ? (scenarioReportOutline.error | slice:0:100) + " ..." : (scenarioReportOutline.error) }}</small></span>
               </td>
               <td class="text-center align-middle text-nowrap">

--- a/chutney/ui/src/app/modules/campaign/components/execution/detail/campaign-execution.component.html
+++ b/chutney/ui/src/app/modules/campaign/components/execution/detail/campaign-execution.component.html
@@ -154,7 +154,7 @@
                   placement="right">
                 </i>
               </td>
-              <td>
+              <td class="align-middle">
                 <ng-container *hasAuthorization="[Authorization.SCENARIO_READ]">
                   <a [routerLink]="['/scenario', scenarioReportOutline.scenarioId, 'executions']"
                     [queryParams]="toQueryParams(scenarioReportOutline)"
@@ -192,7 +192,7 @@
                     </span>
                   }
               </td>
-              <td class="text-center align-middle text-nowrap">
+              <td class="text-center align-middle text-break">
                   <span><small>{{ scenarioReportOutline.datasetId }}</small></span>
               </td>
               <td class="text-center align-middle text-nowrap">

--- a/chutney/ui/src/app/modules/database-admin/components/resultReportList/database-admin-report-list.component.html
+++ b/chutney/ui/src/app/modules/database-admin/components/resultReportList/database-admin-report-list.component.html
@@ -122,7 +122,7 @@
               [ngbTooltip]="ExecutionStatus.toString(execution.status) | translate" placement="right"
             ></i>
           </td>
-          <td>
+          <td class="text-break">
             <ngb-highlight [result]="execution.error"
             [term]="filtersForm.get('keyword').value"></ngb-highlight>
           </td>

--- a/chutney/ui/src/app/modules/dataset/components/dataset-list/dataset-list.component.html
+++ b/chutney/ui/src/app/modules/dataset/components/dataset-list/dataset-list.component.html
@@ -29,7 +29,7 @@
 
   <div class="d-flex flex-row mt-5">
     <div [ngClass]="preview ? 'w-75' : 'w-100'">
-      <table class="table table-sm table-striped table-hover rounded">
+      <table class="table table-sm table-striped table-hover rounded align-middle">
         <thead>
           <tr class="mb-1">
             <th scope="col" class="w10">&nbsp;</th>

--- a/chutney/ui/src/app/modules/dataset/components/dataset-list/dataset-list.component.html
+++ b/chutney/ui/src/app/modules/dataset/components/dataset-list/dataset-list.component.html
@@ -52,7 +52,7 @@
                   aria-hidden="true"></span> {{ 'global.actions.edit' | translate }}
                 </button>
               </td>
-              <td class="pt-2"><span>{{dataset.name}}</span></td>
+              <td class="pt-2 text-break"><span>{{dataset.name}}</span></td>
               <td class="pt-2">
                 @if (dataset.tags.length <= 3) {
                   <span>

--- a/chutney/ui/src/app/modules/scenarios/components/execution/history/list/scenario-executions.component.html
+++ b/chutney/ui/src/app/modules/scenarios/components/execution/history/list/scenario-executions.component.html
@@ -169,7 +169,7 @@
                 <ngb-highlight [result]="execution.environment"
                 [term]="filtersForm.get('keyword').value"></ngb-highlight>
               </td>
-              <td>
+              <td class="text-break">
                   <ngb-highlight [result]="execution.dataset"
                                  [term]="filtersForm.get('keyword').value"></ngb-highlight>
               </td>

--- a/chutney/ui/src/app/modules/scenarios/components/execution/history/list/scenario-executions.component.html
+++ b/chutney/ui/src/app/modules/scenarios/components/execution/history/list/scenario-executions.component.html
@@ -138,7 +138,7 @@
                   [ngbTooltip]="ExecutionStatus.toString(execution.status) | translate" placement="right"
                 ></i>
               </td>
-              <td>
+              <td class="text-break">
                 <ngb-highlight [result]="execution.error"
                 [term]="filtersForm.get('keyword').value"></ngb-highlight>
               </td>

--- a/chutney/ui/src/app/modules/scenarios/components/search-list/scenarios.component.html
+++ b/chutney/ui/src/app/modules/scenarios/components/search-list/scenarios.component.html
@@ -40,7 +40,7 @@
 
 <div class="w-100">
     <span class="ms-3">{{viewedScenarios.length}} / {{scenarios.length}}</span>
-    <div class="table-responsive mb-3 mx-3">
+    <div class="table-responsive mb-3 mx-3 overflow-visible">
         <table class="table table-sm table-striped table-hover">
             <thead>
             <tr class="headers-labels">

--- a/chutney/ui/src/app/modules/scenarios/components/search-list/scenarios.component.html
+++ b/chutney/ui/src/app/modules/scenarios/components/search-list/scenarios.component.html
@@ -41,7 +41,7 @@
 <div class="w-100">
     <span class="ms-3">{{viewedScenarios.length}} / {{scenarios.length}}</span>
     <div class="table-responsive mb-3 mx-3 overflow-visible">
-        <table class="table table-sm table-striped table-hover">
+        <table class="table table-sm table-striped table-hover align-middle">
             <thead>
             <tr class="headers-labels">
                 <th class="filter w3" scope="col" (click)="sortBy('id')">ID

--- a/chutney/ui/src/assets/style/global/_select.scss
+++ b/chutney/ui/src/assets/style/global/_select.scss
@@ -50,6 +50,6 @@ ng-multiselect-dropdown .multiselect-dropdown .dropdown-btn .selected-item-conta
 
 
 ng-multiselect-dropdown .multiselect-dropdown .dropdown-list {
-    display: fixed;
     width: auto;
+    min-width: 100%
 }

--- a/chutney/ui/src/assets/style/global/_select.scss
+++ b/chutney/ui/src/assets/style/global/_select.scss
@@ -39,6 +39,11 @@ $base-color: var(--bs-primary) !important;
     }
 }
 
-
-
-
+ng-multiselect-dropdown .multiselect-dropdown .dropdown-btn .selected-item-container .selected-item {
+    display: flex;
+    span {
+        text-overflow: ellipsis;
+        display: block;
+        overflow: hidden;
+    }
+}

--- a/chutney/ui/src/assets/style/global/_select.scss
+++ b/chutney/ui/src/assets/style/global/_select.scss
@@ -47,3 +47,9 @@ ng-multiselect-dropdown .multiselect-dropdown .dropdown-btn .selected-item-conta
         overflow: hidden;
     }
 }
+
+
+ng-multiselect-dropdown .multiselect-dropdown .dropdown-list {
+    display: fixed;
+    width: auto;
+}


### PR DESCRIPTION
![image](https://github.com/chutney-testing/chutney/assets/138011689/8dd92997-0fd6-4dc3-9efa-cc2656d48440)
No more scrolling bar and the select appear completely

![image](https://github.com/chutney-testing/chutney/assets/138011689/b8346ee7-8c1d-40e5-83f8-78ab8ab07eaa)
The selected element is wrapped and does not overflow

![image](https://github.com/chutney-testing/chutney/assets/138011689/1eaa025c-a07b-4c97-a95b-3be40672516f)
Break-word for superlong words

![image](https://github.com/chutney-testing/chutney/assets/138011689/8046cf44-866c-4ee2-96f6-a9d74c59212a)
The size of the select has the width of the largest element