### PR TITLE
feat: Add SpEL support to RetryWithTimeOutStrategy

### DIFF
--- a/chutney/engine/src/main/java/com/chutneytesting/engine/domain/execution/engine/evaluation/StepDataEvaluator.java
+++ b/chutney/engine/src/main/java/com/chutneytesting/engine/domain/execution/engine/evaluation/StepDataEvaluator.java
@@ -62,8 +62,12 @@ public class StepDataEvaluator {
         return evaluate(o, contextVariables, false);
     }
 
+    public String evaluateString(final String s, final Map<String, Object> contextVariables) throws EvaluationException {
+        return (String) this.evaluate(s, contextVariables);
+    }
+
     public String silentEvaluateString(final String s, final Map<String, Object> contextVariables) throws EvaluationException {
-        return (String) this.evaluate((Object) s, contextVariables, true);
+        return (String) this.evaluate(s, contextVariables, true);
     }
 
     public Target evaluateTarget(final Target target, final Map<String, Object> contextVariables) throws EvaluationException {
@@ -103,16 +107,16 @@ public class StepDataEvaluator {
         Object inputEvaluatedValue;
         if (object instanceof String stringValue) {
             if (hasOnlyOneSpel(stringValue)) {
-              inputEvaluatedValue = Strings.replaceExpression(stringValue, s -> evaluate(parser, evaluationContext, s), EVALUATION_STRING_PREFIX, EVALUATION_STRING_SUFFIX, EVALUATION_STRING_ESCAPE, silentResolve);
+                inputEvaluatedValue = Strings.replaceExpression(stringValue, s -> evaluate(parser, evaluationContext, s), EVALUATION_STRING_PREFIX, EVALUATION_STRING_SUFFIX, EVALUATION_STRING_ESCAPE, silentResolve);
             } else {
-              inputEvaluatedValue = Strings.replaceExpressions(stringValue, s -> evaluate(parser, evaluationContext, s), EVALUATION_STRING_PREFIX, EVALUATION_STRING_SUFFIX, EVALUATION_STRING_ESCAPE, silentResolve);
+                inputEvaluatedValue = Strings.replaceExpressions(stringValue, s -> evaluate(parser, evaluationContext, s), EVALUATION_STRING_PREFIX, EVALUATION_STRING_SUFFIX, EVALUATION_STRING_ESCAPE, silentResolve);
             }
         } else if (object instanceof Map map) {
             Map evaluatedMap = new LinkedHashMap();
             map.forEach(
                 (key, value) -> {
-                  Object keyValue = evaluateObject(key, evaluationContext, silentResolve);
-                  Object valueValue = evaluateObject(value, evaluationContext, silentResolve);
+                    Object keyValue = evaluateObject(key, evaluationContext, silentResolve);
+                    Object valueValue = evaluateObject(value, evaluationContext, silentResolve);
                     evaluatedMap.put(keyValue, valueValue);
                     if (keyValue instanceof String stringKeyValue) {
                         evaluationContext.setVariable(stringKeyValue, valueValue);

--- a/chutney/engine/src/test/java/com/chutneytesting/engine/domain/execution/engine/evaluation/StepDataEvaluatorTest.java
+++ b/chutney/engine/src/test/java/com/chutneytesting/engine/domain/execution/engine/evaluation/StepDataEvaluatorTest.java
@@ -100,7 +100,7 @@ public class StepDataEvaluatorTest {
         assertThat(evaluatedInputs.get("objectAttributeValue")).isEqualTo("attributeValue");
 
         assertThat(evaluatedInputs.get("map")).isInstanceOf(Map.class);
-        Map evaluatedMap = (Map<String, Object>)evaluatedInputs.get("map");
+        Map<String, Object> evaluatedMap = (Map<String, Object>) evaluatedInputs.get("map");
         assertThat(evaluatedMap.get("stringRawValue")).isEqualTo("rawValue");
         assertThat(evaluatedMap.get("objectRawValue")).isEqualTo(testObject);
         assertThat(evaluatedMap.get("destination")).isEqualTo("stringDestination");
@@ -111,13 +111,13 @@ public class StepDataEvaluatorTest {
         assertThat(evaluatedMap.get("objectAttributeValue")).isEqualTo("attributeValue");
 
         assertThat(evaluatedMap.get("innerMap")).isInstanceOf(Map.class);
-        Map evaluatedInnerMap = (Map<Object, Object>)evaluatedMap.get("innerMap");
+        Map<Object, Object> evaluatedInnerMap = (Map<Object, Object>) evaluatedMap.get("innerMap");
         assertThat(evaluatedInnerMap.get("dateTimeFormat")).isEqualTo("ss");
         assertThat(evaluatedInnerMap.get("dateTimeFormatRef")).isEqualTo("ss");
 
 
         assertThat(evaluatedInputs.get("list")).isInstanceOf(List.class);
-        List evaluatedList = (List<Object>)evaluatedInputs.get("list");
+        List<Object> evaluatedList = (List<Object>) evaluatedInputs.get("list");
         assertThat(evaluatedList.get(0)).isEqualTo("rawValue");
         assertThat(evaluatedList.get(1)).isEqualTo(testObject);
         assertThat(evaluatedList.get(2)).isEqualTo("stringDestination");
@@ -127,7 +127,7 @@ public class StepDataEvaluatorTest {
         assertThat(evaluatedList.get(6)).isEqualTo("attributeValue");
 
         assertThat(evaluatedInputs.get("set")).isInstanceOf(Set.class);
-        Set evaluatedSet = (Set<Object>)evaluatedInputs.get("set");
+        Set<Object> evaluatedSet = (Set<Object>) evaluatedInputs.get("set");
         assertThat(evaluatedSet).contains("rawValue");
         assertThat(evaluatedSet).contains(testObject);
         assertThat(evaluatedSet).contains("stringDestination");
@@ -211,6 +211,19 @@ public class StepDataEvaluatorTest {
     }
 
     @Test
+    public void should_resolve_expression_as_string() {
+        // Given
+        Map<String, Object> context = new HashMap<>();
+        context.put("toto", "titi");
+
+        // When
+        String result = sut.evaluateString("test ${#toto}", context);
+
+        // Then
+        assertThat(result).isEqualTo("test titi");
+    }
+
+    @Test
     public void should_evaluate_multiple_spel() {
         // Given
         ScenarioContextImpl scenarioContext = new ScenarioContextImpl();
@@ -247,18 +260,20 @@ public class StepDataEvaluatorTest {
         assertThat(evaluatedInputs.get("twoVariablesWithTextAtBeginning")).isEqualTo("Text - toto - tata");
         assertThat(evaluatedInputs.get("twoVariablesWithTextAtTheEnd")).isEqualTo("toto - tata - text");
 
-        assertThat(((Map)evaluatedInputs.get("object")).get("k1")).isEqualTo("value1");
-        assertThat(((Map)evaluatedInputs.get("objectWithSpaceAfter")).get("k2")).isEqualTo("value2");
-        assertThat(((Map)evaluatedInputs.get("objectWithSpaceBefore")).get("k3")).isEqualTo("value3");
-        assertThat(((Map)evaluatedInputs.get("objectWithSpaceAfterSuffix")).get("k4")).isEqualTo("value4");
-        assertThat(((Map)evaluatedInputs.get("objectWithSpaceBeforePrefix")).get("k5")).isEqualTo("value5");
+        assertThat(((Map) evaluatedInputs.get("object")).get("k1")).isEqualTo("value1");
+        assertThat(((Map) evaluatedInputs.get("objectWithSpaceAfter")).get("k2")).isEqualTo("value2");
+        assertThat(((Map) evaluatedInputs.get("objectWithSpaceBefore")).get("k3")).isEqualTo("value3");
+        assertThat(((Map) evaluatedInputs.get("objectWithSpaceAfterSuffix")).get("k4")).isEqualTo("value4");
+        assertThat(((Map) evaluatedInputs.get("objectWithSpaceBeforePrefix")).get("k5")).isEqualTo("value5");
     }
 
-    private class TestObject {
-        private String attribute;
+    private static class TestObject {
+        private final String attribute;
+
         public TestObject(String attribute) {
             this.attribute = attribute;
         }
+
         public String attribute() {
             return attribute;
         }

--- a/chutney/engine/src/test/java/com/chutneytesting/engine/domain/execution/strategies/RetryWithTimeOutStrategyTest.java
+++ b/chutney/engine/src/test/java/com/chutneytesting/engine/domain/execution/strategies/RetryWithTimeOutStrategyTest.java
@@ -7,8 +7,10 @@
 
 package com.chutneytesting.engine.domain.execution.strategies;
 
-import static com.chutneytesting.engine.api.execution.StatusDto.SUCCESS;
 import static com.chutneytesting.engine.domain.execution.ScenarioExecution.createScenarioExecution;
+import static com.chutneytesting.engine.domain.execution.report.Status.FAILURE;
+import static com.chutneytesting.engine.domain.execution.report.Status.SUCCESS;
+import static java.util.Collections.emptyMap;
 import static java.util.List.of;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -17,6 +19,7 @@ import static org.mockito.AdditionalMatchers.or;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.atMost;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -25,23 +28,30 @@ import static org.mockito.Mockito.when;
 
 import com.chutneytesting.ExecutionConfiguration;
 import com.chutneytesting.engine.api.execution.ExecutionRequestDto;
+import com.chutneytesting.engine.api.execution.StatusDto;
 import com.chutneytesting.engine.api.execution.StepExecutionReportDto;
 import com.chutneytesting.engine.api.execution.TestEngine;
 import com.chutneytesting.engine.domain.execution.ScenarioExecution;
+import com.chutneytesting.engine.domain.execution.engine.evaluation.EvaluationException;
 import com.chutneytesting.engine.domain.execution.engine.evaluation.StepDataEvaluator;
 import com.chutneytesting.engine.domain.execution.engine.scenario.ScenarioContextImpl;
 import com.chutneytesting.engine.domain.execution.engine.step.Step;
 import com.chutneytesting.engine.domain.execution.report.Status;
 import com.chutneytesting.tools.Jsons;
 import java.lang.reflect.Field;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.assertj.core.util.Lists;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
 import org.mockito.stubbing.OngoingStubbing;
 import org.springframework.util.ReflectionUtils;
 
@@ -49,7 +59,7 @@ public class RetryWithTimeOutStrategyTest {
 
     private final RetryWithTimeOutStrategy strategyUnderTest = new RetryWithTimeOutStrategy();
 
-    private StrategyProperties properties(String timeOut, String retryDelay) {
+    private static StrategyProperties properties(String timeOut, String retryDelay) {
         StrategyProperties strategyProperties = new StrategyProperties();
         strategyProperties.setProperty("timeOut", timeOut);
         strategyProperties.setProperty("retryDelay", retryDelay);
@@ -64,7 +74,8 @@ public class RetryWithTimeOutStrategyTest {
         StepStrategyDefinition strategyDefinition = new StepStrategyDefinition("", strategyProperties);
         Step step = mock(Step.class);
         when(step.strategy()).thenReturn(Optional.of(strategyDefinition));
-        assertThatThrownBy(() -> strategyUnderTest.execute(createScenarioExecution(null), step, null, null))
+        when(step.dataEvaluator()).thenReturn(new StepDataEvaluator(null));
+        assertThatThrownBy(() -> strategyUnderTest.execute(createScenarioExecution(null), step, new ScenarioContextImpl(), null))
             .isInstanceOf(IllegalArgumentException.class);
     }
 
@@ -75,23 +86,21 @@ public class RetryWithTimeOutStrategyTest {
 
         Step step = mock(Step.class);
         when(step.strategy()).thenReturn(Optional.of(strategyDefinition));
-        assertThatThrownBy(() -> strategyUnderTest.execute(createScenarioExecution(null), step, null, null))
+        assertThatThrownBy(() -> strategyUnderTest.execute(createScenarioExecution(null), step, new ScenarioContextImpl(), null))
             .isInstanceOf(IllegalStateException.class);
     }
 
     @Test
     public void step_succeeds_execute_only_once() {
-        // Given
         StrategyProperties strategyProperties = properties("100 sec", "50 ms");
         StepStrategyDefinition strategyDefinition = new StepStrategyDefinition("", strategyProperties);
 
-        // When
         Step step = mock(Step.class);
         when(step.strategy()).thenReturn(Optional.of(strategyDefinition));
-        strategyUnderTest.execute(createScenarioExecution(null), step, null, null);
+        when(step.dataEvaluator()).thenReturn(new StepDataEvaluator(null));
+        strategyUnderTest.execute(createScenarioExecution(null), step, new ScenarioContextImpl(), null);
 
-        // Then
-        verify(step, times(1)).execute(any(), any(), any() );
+        verify(step, times(1)).execute(any(), any(), any());
     }
 
     @Test
@@ -99,11 +108,11 @@ public class RetryWithTimeOutStrategyTest {
         StrategyProperties strategyProperties = properties("1 sec", "50 ms");
         StepStrategyDefinition strategyDefinition = new StepStrategyDefinition("", strategyProperties);
 
-        Step step = mockStep(Status.FAILURE);
+        Step step = mockStep(FAILURE);
         when(step.strategy()).thenReturn(Optional.of(strategyDefinition));
         long start = System.currentTimeMillis();
         ScenarioExecution scenarioExecution = createScenarioExecution(null);
-        strategyUnderTest.execute(scenarioExecution, step, null, null);
+        strategyUnderTest.execute(scenarioExecution, step, new ScenarioContextImpl(), null);
 
         long executionDuration = System.currentTimeMillis() - start;
         assertThat(executionDuration).isBetween(1000L, 2000L);
@@ -116,11 +125,11 @@ public class RetryWithTimeOutStrategyTest {
         StrategyProperties strategyProperties = properties("0.1 sec", "5 ms");
         StepStrategyDefinition strategyDefinition = new StepStrategyDefinition("", strategyProperties);
 
-        Step step = mockStep(Status.FAILURE);
+        Step step = mockStep(FAILURE);
         when(step.strategy()).thenReturn(Optional.of(strategyDefinition));
         ScenarioExecution scenarioExecution = createScenarioExecution(null);
         stopExecution(scenarioExecution);
-        Status stepExecutedStatus = strategyUnderTest.execute(scenarioExecution, step, null, null);
+        Status stepExecutedStatus = strategyUnderTest.execute(scenarioExecution, step, new ScenarioContextImpl(), null);
 
         verify(step, times(1)).execute(any(), any(), any());
         assertThat(stepExecutedStatus).isEqualTo(Status.STOPPED);
@@ -131,9 +140,9 @@ public class RetryWithTimeOutStrategyTest {
         StrategyProperties strategyProperties = properties("1 sec", "5 ms");
         StepStrategyDefinition strategyDefinition = new StepStrategyDefinition("", strategyProperties);
 
-        Step step = mockStep(Status.FAILURE, Status.FAILURE, Status.FAILURE, Status.SUCCESS);
+        Step step = mockStep(FAILURE, FAILURE, FAILURE, SUCCESS);
         when(step.strategy()).thenReturn(Optional.of(strategyDefinition));
-        strategyUnderTest.execute(createScenarioExecution(null), step, null, null);
+        strategyUnderTest.execute(createScenarioExecution(null), step, new ScenarioContextImpl(), null);
 
         verify(step, times(4)).execute(any(), any(), any());
     }
@@ -143,10 +152,10 @@ public class RetryWithTimeOutStrategyTest {
         StrategyProperties strategyProperties = properties("1 sec", "5 ms");
         StepStrategyDefinition strategyDefinition = new StepStrategyDefinition("", strategyProperties);
 
-        Step step = mockStep(Status.FAILURE, Status.FAILURE, Status.SUCCESS);
+        Step step = mockStep(FAILURE, FAILURE, SUCCESS);
         when(step.strategy()).thenReturn(Optional.of(strategyDefinition));
         when(step.errors()).thenReturn(of("Error message"));
-        strategyUnderTest.execute(createScenarioExecution(null), step, null, null);
+        strategyUnderTest.execute(createScenarioExecution(null), step, new ScenarioContextImpl(), null);
 
         verify(step, times(3)).execute(any(), any(), any());
         verify(step).addErrorMessage(eq("Error(s) on last step execution:"));
@@ -162,7 +171,7 @@ public class RetryWithTimeOutStrategyTest {
         List<StepExecutionStrategy> strategiesMock = Lists.newArrayList();
 
         List<Step> mockSteps = Arrays.stream(Status.values())
-            .filter(s -> !Status.FAILURE.equals(s))
+            .filter(s -> !FAILURE.equals(s))
             .map(status -> {
                 Step step = mock(Step.class);
                 StepStrategyDefinition sd = mock(StepStrategyDefinition.class);
@@ -189,8 +198,11 @@ public class RetryWithTimeOutStrategyTest {
         strategiesMock.forEach(strat -> verify(strat, times(1)).execute(any(), any(), any(), any(), any()));
     }
 
-    @Test
-    public void steps_container_retry_until_all_steps_in_success() {
+    @ParameterizedTest
+    @MethodSource("retryStrategyProperties")
+    public void steps_container_retry_until_all_steps_in_success(StrategyProperties retryProperties, Map<String, Object> context) {
+        String timeOut = retryProperties.getProperty("timeOut", String.class);
+        String retryDelay = retryProperties.getProperty("retryDelay", String.class);
 
         Step rootStep = mock(Step.class);
 
@@ -204,9 +216,9 @@ public class RetryWithTimeOutStrategyTest {
         StepStrategyDefinition sd3 = mock(StepStrategyDefinition.class);
         when(step3.strategy()).thenReturn(Optional.of(sd3));
 
-        StepExecutionStrategy strategy1 = mockStrategy(Status.FAILURE, Status.FAILURE, Status.FAILURE, Status.SUCCESS);
-        StepExecutionStrategy strategy2 = mockStrategy(Status.SUCCESS);
-        StepExecutionStrategy strategy3 = mockStrategy(Status.FAILURE, Status.FAILURE, Status.FAILURE, Status.FAILURE, Status.FAILURE, Status.FAILURE, Status.SUCCESS);
+        StepExecutionStrategy strategy1 = mockStrategy(FAILURE, FAILURE, FAILURE, SUCCESS);
+        StepExecutionStrategy strategy2 = mockStrategy(SUCCESS);
+        StepExecutionStrategy strategy3 = mockStrategy(FAILURE, FAILURE, FAILURE, FAILURE, FAILURE, FAILURE, SUCCESS);
 
         when(rootStep.subSteps()).thenReturn(Lists.newArrayList(step1, step2, step3));
         when(rootStep.isParentStep()).thenReturn(true);
@@ -217,15 +229,26 @@ public class RetryWithTimeOutStrategyTest {
         when(strategies.buildStrategyFrom(step2)).thenReturn(strategy2);
         when(strategies.buildStrategyFrom(step3)).thenReturn(strategy3);
 
-        StrategyProperties properties = properties("1 min", "5 ms");
-        StepStrategyDefinition strategyDefinition = new StepStrategyDefinition("", properties);
+        StepStrategyDefinition strategyDefinition = new StepStrategyDefinition("", retryProperties);
         when(rootStep.strategy()).thenReturn(Optional.of(strategyDefinition));
 
-        strategyUnderTest.execute(createScenarioExecution(null), rootStep, new ScenarioContextImpl(), strategies);
+        ScenarioContextImpl scenarioContext = new ScenarioContextImpl();
+        scenarioContext.putAll(context);
+        strategyUnderTest.execute(createScenarioExecution(null), rootStep, scenarioContext, strategies);
 
         verify(strategy1, times(10)).execute(any(), eq(step1), any(), any(), eq(strategies));
         verify(strategy2, times(7)).execute(any(), eq(step2), any(), any(), eq(strategies));
         verify(strategy3, times(7)).execute(any(), eq(step3), any(), any(), eq(strategies));
+
+        ArgumentCaptor<String> infoCaptor = ArgumentCaptor.forClass(String.class);
+        verify(rootStep, atLeastOnce()).addInformation(infoCaptor.capture());
+
+        List<String> capturedInfos = infoCaptor.getAllValues();
+
+        String expectedTimeOut = timeOut.startsWith("${") ? "10 s" : timeOut;
+        String expectedRetryDelay = retryDelay.startsWith("${") ? "150 ms" : retryDelay;
+        String expectedInfo = String.format("Retry strategy definition : [timeOut %s] [delay %s]", expectedTimeOut, expectedRetryDelay);
+        assertThat(capturedInfos).anyMatch(info -> info.contains(expectedInfo));
     }
 
     @Test
@@ -238,44 +261,66 @@ public class RetryWithTimeOutStrategyTest {
         StepExecutionReportDto result = testEngine.execute(requestDto);
 
         // T
-        assertThat(result).hasFieldOrPropertyWithValue("status", SUCCESS);
+        assertThat(result).hasFieldOrPropertyWithValue("status", StatusDto.SUCCESS);
         assertThat(result.steps).hasSize(2);
         assertThat(result.steps.get(1).name).isEqualTo("Step 2 Parent : value");
     }
 
 
     @ParameterizedTest
-    @MethodSource("retryStepParameters")
-    public void should_reset_step_execution_before_each_retry(Status[] stepStatus) {
+    @MethodSource("retryStepStatus")
+    public void should_reset_step_execution_before_each_retry(List<Status> stepStatus) {
         StrategyProperties strategyProperties = properties("1 sec", "5 ms");
         StepStrategyDefinition strategyDefinition = new StepStrategyDefinition("", strategyProperties);
-        Step step = mockStep(stepStatus);
+        Step step = mockStep(stepStatus.toArray(new Status[0]));
         when(step.strategy()).thenReturn(Optional.of(strategyDefinition));
 
-        strategyUnderTest.execute(createScenarioExecution(null), step, null, null);
+        strategyUnderTest.execute(createScenarioExecution(null), step, new ScenarioContextImpl(), null);
 
-        verify(step, times(stepStatus.length - 1)).resetExecution();
+        verify(step, times(stepStatus.size() - 1)).resetExecution();
     }
 
     @ParameterizedTest
-    @MethodSource("retryStepParameters")
-    public void should_add_information_about_strategy_and_retries(Status[] stepStatus) {
-        StrategyProperties strategyProperties = properties("1 sec", "5 ms");
-        StepStrategyDefinition strategyDefinition = new StepStrategyDefinition("", strategyProperties);
-        Step step = mockStep(stepStatus);
+    @MethodSource("informationParameters")
+    public void should_add_information_about_strategy_and_retries(List<Status> stepStatus, StrategyProperties retryProperties, Map<String, Object> context) {
+        StepStrategyDefinition strategyDefinition = new StepStrategyDefinition("", retryProperties);
+        Step step = mockStep(stepStatus.toArray(new Status[0]));
         when(step.strategy()).thenReturn(Optional.of(strategyDefinition));
+        when(step.dataEvaluator()).thenReturn(new StepDataEvaluator(null));
 
-        strategyUnderTest.execute(createScenarioExecution(null), step, null, null);
+        ScenarioContextImpl scenarioContext = new ScenarioContextImpl();
+        scenarioContext.putAll(context);
+        strategyUnderTest.execute(createScenarioExecution(null), step, scenarioContext, null);
 
-        verify(step, times(2 * stepStatus.length))
+        String timeOut = retryProperties.getProperty("timeOut", String.class);
+        String expectedTimeout = context.getOrDefault("timeOut", timeOut).toString();
+        String retryDelay = retryProperties.getProperty("retryDelay", String.class);
+        String expectedRetryDelay = context.getOrDefault("retryDelay", retryDelay).toString();
+        verify(step, times(2 * stepStatus.size()))
             .addInformation(
                 or(
                     and(
-                        contains(strategyProperties.getProperty("timeOut", String.class)),
-                        contains(strategyProperties.getProperty("retryDelay", String.class))
+                        contains(expectedTimeout),
+                        contains(expectedRetryDelay)
                     ),
                     contains("Try number")
                 ));
+    }
+
+    @Test
+    void should_throw_evaluation_exception_when_strategy_properties_not_evaluable() {
+        StrategyProperties strategyProperties = new StrategyProperties();
+        strategyProperties.setProperty("timeOut", "${#timeOut}");
+        strategyProperties.setProperty("retryDelay", "${#retryDelay}");
+        StepStrategyDefinition strategyDefinition = new StepStrategyDefinition("", strategyProperties);
+
+        Step step = mock(Step.class);
+        when(step.strategy()).thenReturn(Optional.of(strategyDefinition));
+        when(step.dataEvaluator()).thenReturn(new StepDataEvaluator(null));
+
+        assertThatThrownBy(() ->
+            strategyUnderTest.execute(ScenarioExecution.createScenarioExecution(null), step, new ScenarioContextImpl(), null)
+        ).isInstanceOf(EvaluationException.class);
     }
 
     private StepExecutionStrategy mockStrategy(Status... expectedStatus) {
@@ -292,22 +337,13 @@ public class RetryWithTimeOutStrategyTest {
     private Step mockStep(Status... expectedStatus) {
         Step stepMock = mock(Step.class);
         OngoingStubbing<Status> stub = when(stepMock.execute(any(), any(), any()));
-
         for (Status st : expectedStatus) {
             stub = stub.thenReturn(st);
         }
 
-        return stepMock;
-    }
+        when(stepMock.dataEvaluator()).thenReturn(new StepDataEvaluator(null));
 
-    @SuppressWarnings("unused")
-    private static Object[] retryStepParameters() {
-        return new Object[] {
-            new Object[]{new Status[]{Status.SUCCESS}},
-            new Object[]{new Status[]{Status.FAILURE, Status.SUCCESS}},
-            new Object[]{new Status[]{Status.FAILURE, Status.FAILURE, Status.SUCCESS}},
-            new Object[]{new Status[]{Status.FAILURE, Status.FAILURE, Status.FAILURE, Status.SUCCESS}},
-        };
+        return stepMock;
     }
 
 
@@ -317,4 +353,44 @@ public class RetryWithTimeOutStrategyTest {
         ReflectionUtils.setField(stopField, scenarioExecution, true);
     }
 
+    private static Stream<Arguments> informationParameters() {
+        return zipStream(retryStepStatus(), retryStrategyProperties());
+    }
+
+    private static Stream<Arguments> retryStepStatus() {
+        return Stream.of(
+            Arguments.of(List.of(SUCCESS)),
+            Arguments.of(List.of(FAILURE, SUCCESS)),
+            Arguments.of(List.of(FAILURE, FAILURE, SUCCESS)),
+            Arguments.of(List.of(FAILURE, FAILURE, FAILURE, SUCCESS))
+        );
+    }
+
+
+    private static Stream<Arguments> retryStrategyProperties() {
+        return Stream.of(
+            Arguments.of(properties("1 min", "5 ms"), emptyMap()),
+            Arguments.of(properties("${#timeOut} s", "${#retryDelay}"), Map.of("timeOut", 10L, "retryDelay", "150 ms"))
+        );
+    }
+
+    private static Stream<Arguments> zipStream(Stream<Arguments> a, Stream<Arguments> b) {
+        var aList = a.toList();
+        var bList = b.toList();
+
+        var biggestList = aList.size() >= bList.size() ? aList : bList;
+        var smallestList = aList == biggestList ? bList : aList;
+        int smallestSize = smallestList.size();
+        var resultList = new ArrayList<Arguments>();
+        for (int i = 0; i < biggestList.size(); i++) {
+            Arguments bObjects = biggestList.get(i);
+            Arguments sObjects = smallestList.get(i % smallestSize);
+            var zipArgs = new ArrayList<>();
+            zipArgs.addAll(Arrays.stream(bObjects.get()).toList());
+            zipArgs.addAll(Arrays.stream(sObjects.get()).toList());
+            resultList.add(Arguments.of(zipArgs.toArray()));
+        }
+
+        return resultList.stream();
+    }
 }


### PR DESCRIPTION
- Update RetryWithTimeOutStrategy to evaluate SpEL expressions in timeOut and retryDelay parameters
- Add tests to verify SpEL expression evaluation and logging
- Ensure proper handling of mixed SpEL and non-SpEL values
- Improve logging to show evaluated SpEL expressions
![image](https://github.com/user-attachments/assets/37e70be7-4a35-4033-b6e3-dc78f6c6f47a)
![image](https://github.com/user-attachments/assets/86884ebd-844c-419e-adb8-65ce793432bc)
